### PR TITLE
Release v0.2.1: Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      deployments: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@info-lounge/firestore-typed",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@info-lounge/firestore-typed",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@info-lounge/firestore-typed",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Type-safe, low-level wrapper for Firebase Firestore with enhanced validation and developer experience",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

This PR fixes the release workflow permissions issue encountered during v0.2.0 release and prepares for v0.2.1 release.

## Changes

### 🐛 Bug Fixes
- **Release Workflow**: Added `deployments: write` permission to fix GitHub deployment creation error
- **Version Bump**: Updated to v0.2.1 for the next release

### 📝 Previous v0.2.0 Changes Included
- Major architectural redesign with collection-level validators
- firebase-admin restricted to v12.x due to v13 compatibility issues
- Complete documentation updates

## Release Context

During the v0.2.0 release, the GitHub Actions workflow failed at the deployment creation step due to insufficient permissions. This PR includes the fix to ensure smooth releases going forward.

## Test Status

- ✅ All 209 tests passing
- ✅ Lint checks passing
- ✅ No vulnerabilities

🤖 Generated with [Claude Code](https://claude.ai/code)