### PR TITLE
ci: replace continue-on-error with always() conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,19 +30,18 @@ jobs:
 
       - name: Run linter
         run: npm run lint
-        continue-on-error: true
 
       - name: Check formatting
+        if: always()
         run: npm run format:check
-        continue-on-error: true
 
       - name: Type check
+        if: always()
         run: npm run typecheck
-        continue-on-error: true
 
       - name: Run tests with coverage
+        if: always()
         run: npm run test:coverage
-        continue-on-error: true
 
       - name: Upload coverage to Codecov
         if: matrix.node-version == '22.x' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')


### PR DESCRIPTION
## Summary
- Removed `continue-on-error: true` from all CI steps
- Added `if: always()` conditions to ensure all steps run regardless of previous failures
- This allows individual step failures to be properly detected while still running all checks

## Test plan
- [ ] Verify CI workflow runs all steps even when one fails
- [ ] Confirm job fails when any step fails (no false positives)
- [ ] Check that Codecov upload only runs on success

🤖 Generated with [Claude Code](https://claude.ai/code)