### PR TITLE
chore(deps): upgrade typia to v12.1 and widen peer dependency range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "tsdown": "^0.15.0",
         "typescript": "~5.9.2",
         "typescript-eslint": "^8.39.0",
-        "typia": "^9.7.1",
+        "typia": "^12.1.1",
         "vitest": "^3.2.4",
         "zod": "^4.0.17"
       },
@@ -32,7 +32,7 @@
       },
       "peerDependencies": {
         "firebase-admin": "^13.5.0",
-        "typia": "^9.7.2",
+        "typia": ">=9.7.2 <13",
         "zod": "^4.0.17"
       },
       "peerDependenciesMeta": {
@@ -1962,13 +1962,6 @@
         "win32"
       ]
     },
-    "node_modules/@samchon/openapi": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/@samchon/openapi/-/openapi-4.7.2.tgz",
-      "integrity": "sha512-yj6kGWHtKK85wfJXrSmWqLWjfCd98SAvCTsVDlej2s7OfXXHqA4hmgPRNrAPIQRVi00xn26qL1PChjq1MhzlRQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -2250,7 +2243,6 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -2450,6 +2442,46 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@typia/core": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@typia/core/-/core-12.1.1.tgz",
+      "integrity": "sha512-SfyugTNTCJa75pVwSXwfx6SwvS5YcNOCBg8VjxqykhSgCyoAXkZtc2PsWEkeeaB8EPut1JRBCrzlWtsXo1EZ8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typia/interface": "^12.1.1",
+        "@typia/utils": "^12.1.1"
+      }
+    },
+    "node_modules/@typia/interface": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@typia/interface/-/interface-12.1.1.tgz",
+      "integrity": "sha512-FKLpgNX1mrGnPfeXhU6ztRyMhLvuK13OY8MgqaIucl59XNyCVtcRqgnCMc7dJGLpXEveVp3N5a5VGyZdNUHnCQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typia/transform": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@typia/transform/-/transform-12.1.1.tgz",
+      "integrity": "sha512-RbWB9L/aqcBTbPrJBOYpIg8IyQh6eGliElAFww40F7QlgsXIlk13twjTV3EEWXvgvOTl5eOSDWUKYgL7iAgoOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typia/core": "^12.1.1",
+        "@typia/interface": "^12.1.1",
+        "@typia/utils": "^12.1.1"
+      }
+    },
+    "node_modules/@typia/utils": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@typia/utils/-/utils-12.1.1.tgz",
+      "integrity": "sha512-RQSHMEyVfPnpQJHGfFe2pxU1H5lJPUBF9CQcCB6/EtI+QKcBj/QmQBOJX7a/WRyvC5ojJlJGL0DEylufhBKxkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typia/interface": "^12.1.1"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
@@ -2617,7 +2649,6 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -2669,7 +2700,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3601,7 +3631,6 @@
       "integrity": "sha512-iy2GE3MHrYTL5lrCtMZ0X1KLEKKUjmK0kzwcnefhR66txcEmXZD2YWgR5GNdcEwkNx3a0siYkSvl0vIC+Svjmg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6025,7 +6054,6 @@
       "integrity": "sha512-iMmuD72XXLf26Tqrv1cryNYLX6NNPLhZ3AmNkSf8+xda0H+yijjGJ+wVT9UdBUHOpKzq9RjKtQKRCWoEKQQBZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.95.0",
         "@rolldown/pluginutils": "1.0.0-beta.45"
@@ -6640,7 +6668,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6830,7 +6857,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6864,14 +6890,17 @@
       }
     },
     "node_modules/typia": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-9.7.2.tgz",
-      "integrity": "sha512-eLIKd0KHZtSvbsA+FYwX+Y0ZBt0BwVGz3GgODQX+6GfGL4DOzKW02LEx62oUZg6vCQX1BL5xyiPXAIdW+Hc51g==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/typia/-/typia-12.1.1.tgz",
+      "integrity": "sha512-sgUjpsSW8EhvVoLVbalMyejo9XT42cJUPqFPmXPdf/bIh7xY0rIiNF4CJc9oTXZpqtiZR9II7M8qZ0dYkg93Gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@samchon/openapi": "^4.7.1",
         "@standard-schema/spec": "^1.0.0",
+        "@typia/core": "^12.1.1",
+        "@typia/interface": "^12.1.1",
+        "@typia/transform": "^12.1.1",
+        "@typia/utils": "^12.1.1",
         "commander": "^10.0.0",
         "comment-json": "^4.2.3",
         "inquirer": "^8.2.5",
@@ -6882,7 +6911,7 @@
         "typia": "lib/executable/typia.js"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.0 <5.10.0"
+        "typescript": ">=4.8.0 <7.0.0"
       }
     },
     "node_modules/unconfig": {
@@ -6945,7 +6974,6 @@
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -7062,7 +7090,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7076,7 +7103,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "license": "MIT",
   "peerDependencies": {
     "firebase-admin": "^13.5.0",
-    "typia": "^9.7.2",
+    "typia": ">=9.7.2 <13",
     "zod": "^4.0.17"
   },
   "peerDependenciesMeta": {
@@ -78,7 +78,7 @@
     "tsdown": "^0.15.0",
     "typescript": "~5.9.2",
     "typescript-eslint": "^8.39.0",
-    "typia": "^9.7.1",
+    "typia": "^12.1.1",
     "vitest": "^3.2.4",
     "zod": "^4.0.17"
   },


### PR DESCRIPTION
## Summary

Upgrades typia from v9.7 to v12.1. This is the first step toward a future TypeScript 7 + typia v13 migration (second step: TypeScript 6.0 upgrade → final step: typia v13 + ttsc after TS7 GA).

## Changes

- **devDependencies**: `typia` `^9.7.1` → `^12.1.1`
- **peerDependencies**: `typia` `^9.7.2` → `>=9.7.2 <13`
  - v12.1 is the last generation supporting TypeScript `<7.0.0` (v13 requires typescript@7 + ttsc, hence the `<13` cap)
  - Consumers can use any typia version from v9 to v12 without peer warnings

## Background

| typia | TypeScript peer requirement |
|---|---|
| v9–v12.0 | `>=4.8.0 <5.10.0` |
| **v12.1** | `>=4.8.0 <7.0.0` (TS 6 compatible) |
| v13 | typescript@7 + ttsc only |

The breaking changes in v10–v12 (LLM schema unification in v11, monorepo split in v12) do not affect this project's usage surface (`typia generate` + `typia.createAssert<T>()`).

## Verification

- ✅ `npm test` — all 240 tests pass (including typia:generate)
- ✅ `npm run typecheck`
- ✅ `npm run lint`
- ✅ `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)