### PR TITLE
refactor(tests): linearize error assertions and re-enable vitest/no-conditional-expect

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,8 +40,6 @@ export default tseslint.config(
     },
     rules: {
       ...vitestPlugin.configs.recommended.rules,
-      // Tests assert typed error details inside catch blocks throughout the suite
-      'vitest/no-conditional-expect': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',

--- a/src/__tests__/__helpers__/catch-error.helper.ts
+++ b/src/__tests__/__helpers__/catch-error.helper.ts
@@ -1,0 +1,15 @@
+/**
+ * Runs a function that is expected to throw (or reject) and returns the
+ * thrown error. Fails the test if nothing is thrown.
+ *
+ * Keeps error-detail assertions linear so tests comply with
+ * `vitest/no-conditional-expect` (no `expect` inside catch blocks).
+ */
+export async function catchError<T = unknown>(fn: () => unknown): Promise<T> {
+  try {
+    await fn()
+  } catch (error) {
+    return error as T
+  }
+  throw new Error('Expected function to throw, but it did not')
+}

--- a/src/__tests__/firestore-typed.integration.test.ts
+++ b/src/__tests__/firestore-typed.integration.test.ts
@@ -4,6 +4,7 @@ import { FirestoreTypedValidationError } from '../errors/errors'
 import { createFirebaseAdminMock } from './__helpers__/firebase-mock.helper'
 import { type TestEntity } from './__helpers__/test-entities.helper'
 import { validateTestEntity } from './__helpers__/typia-validators/__generated__/test-entity-validators.helper'
+import { catchError } from './__helpers__/catch-error.helper'
 
 vi.mock('firebase-admin/firestore', async () => {
   const mockHelper = await import('./__helpers__/firebase-mock.helper')
@@ -68,16 +69,13 @@ describe('FirestoreTyped', () => {
           name: 'John Doe',
         } as any
 
-        try {
-          await collection.add(invalidData)
-          expect.fail('Should have thrown an error')
-        } catch (error) {
-          expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-          const validationError = error as FirestoreTypedValidationError
-          if (validationError.originalError instanceof Error) {
-            expect(validationError.originalError.message).toContain('expect to be string')
-          }
-        }
+        const error = await catchError<FirestoreTypedValidationError>(() =>
+          collection.add(invalidData),
+        )
+
+        expect(error).toBeInstanceOf(FirestoreTypedValidationError)
+        expect(error.originalError).toBeInstanceOf(Error)
+        expect((error.originalError as Error).message).toContain('expect to be string')
       })
 
       it('should skip validation when validateOnWrite is false', async () => {

--- a/src/__tests__/validation.integration.test.ts
+++ b/src/__tests__/validation.integration.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { getFirestoreTyped } from '../index'
 import { FirestoreTypedValidationError } from '../errors/errors'
+import { catchError } from './__helpers__/catch-error.helper'
 
 vi.mock('firebase-admin/firestore', async () => {
   const mockHelper = await import('./__helpers__/firebase-mock.helper')
@@ -83,33 +84,23 @@ describe('FirestoreTyped Validation', () => {
     })
 
     it('should reject null data', async () => {
-      try {
-        await collection.add(null as any)
-        expect.fail('Should have thrown an error')
-      } catch (error) {
-        expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-        const validationError = error as FirestoreTypedValidationError
-        if (validationError.originalError instanceof Error) {
-          expect(validationError.originalError.message).toContain('Data must be an object')
-        } else {
-          expect(String(validationError.originalError)).toContain('Data must be an object')
-        }
-      }
+      const error = await catchError<FirestoreTypedValidationError>(() =>
+        collection.add(null as any),
+      )
+
+      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
+      expect(error.originalError).toBeInstanceOf(Error)
+      expect((error.originalError as Error).message).toContain('Data must be an object')
     })
 
     it('should reject undefined data', async () => {
-      try {
-        await collection.add(undefined as any)
-        expect.fail('Should have thrown an error')
-      } catch (error) {
-        expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-        const validationError = error as FirestoreTypedValidationError
-        if (validationError.originalError instanceof Error) {
-          expect(validationError.originalError.message).toContain('Data must be an object')
-        } else {
-          expect(String(validationError.originalError)).toContain('Data must be an object')
-        }
-      }
+      const error = await catchError<FirestoreTypedValidationError>(() =>
+        collection.add(undefined as any),
+      )
+
+      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
+      expect(error.originalError).toBeInstanceOf(Error)
+      expect((error.originalError as Error).message).toContain('Data must be an object')
     })
 
     it('should reject data with missing required fields', async () => {
@@ -118,18 +109,13 @@ describe('FirestoreTyped Validation', () => {
         // missing email, age, status, createdAt
       }
 
-      try {
-        await collection.add(invalidUser as any)
-        expect.fail('Should have thrown an error')
-      } catch (error) {
-        expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-        const validationError = error as FirestoreTypedValidationError
-        if (validationError.originalError instanceof Error) {
-          expect(validationError.originalError.message).toContain('Email is required')
-        } else {
-          expect(String(validationError.originalError)).toContain('Email is required')
-        }
-      }
+      const error = await catchError<FirestoreTypedValidationError>(() =>
+        collection.add(invalidUser as any),
+      )
+
+      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
+      expect(error.originalError).toBeInstanceOf(Error)
+      expect((error.originalError as Error).message).toContain('Email is required')
     })
 
     it('should reject data with invalid name length', async () => {
@@ -141,22 +127,15 @@ describe('FirestoreTyped Validation', () => {
         createdAt: new Date(),
       }
 
-      try {
-        await collection.add(invalidUser)
-        expect.fail('Should have thrown an error')
-      } catch (error) {
-        expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-        const validationError = error as FirestoreTypedValidationError
-        if (validationError.originalError instanceof Error) {
-          expect(validationError.originalError.message).toContain(
-            'Name must be between 2 and 50 characters',
-          )
-        } else {
-          expect(String(validationError.originalError)).toContain(
-            'Name must be between 2 and 50 characters',
-          )
-        }
-      }
+      const error = await catchError<FirestoreTypedValidationError>(() =>
+        collection.add(invalidUser),
+      )
+
+      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
+      expect(error.originalError).toBeInstanceOf(Error)
+      expect((error.originalError as Error).message).toContain(
+        'Name must be between 2 and 50 characters',
+      )
     })
 
     it('should reject data with invalid email format', async () => {
@@ -168,22 +147,15 @@ describe('FirestoreTyped Validation', () => {
         createdAt: new Date(),
       }
 
-      try {
-        await collection.add(invalidUser)
-        expect.fail('Should have thrown an error')
-      } catch (error) {
-        expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-        const validationError = error as FirestoreTypedValidationError
-        if (validationError.originalError instanceof Error) {
-          expect(validationError.originalError.message).toContain(
-            'Email must be a valid email address',
-          )
-        } else {
-          expect(String(validationError.originalError)).toContain(
-            'Email must be a valid email address',
-          )
-        }
-      }
+      const error = await catchError<FirestoreTypedValidationError>(() =>
+        collection.add(invalidUser),
+      )
+
+      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
+      expect(error.originalError).toBeInstanceOf(Error)
+      expect((error.originalError as Error).message).toContain(
+        'Email must be a valid email address',
+      )
     })
 
     it('should reject data with invalid age range', async () => {
@@ -195,18 +167,13 @@ describe('FirestoreTyped Validation', () => {
         createdAt: new Date(),
       }
 
-      try {
-        await collection.add(invalidUser)
-        expect.fail('Should have thrown an error')
-      } catch (error) {
-        expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-        const validationError = error as FirestoreTypedValidationError
-        if (validationError.originalError instanceof Error) {
-          expect(validationError.originalError.message).toContain('Age must be between 0 and 120')
-        } else {
-          expect(String(validationError.originalError)).toContain('Age must be between 0 and 120')
-        }
-      }
+      const error = await catchError<FirestoreTypedValidationError>(() =>
+        collection.add(invalidUser),
+      )
+
+      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
+      expect(error.originalError).toBeInstanceOf(Error)
+      expect((error.originalError as Error).message).toContain('Age must be between 0 and 120')
     })
 
     it('should reject data with invalid status', async () => {
@@ -218,22 +185,15 @@ describe('FirestoreTyped Validation', () => {
         createdAt: new Date(),
       }
 
-      try {
-        await collection.add(invalidUser)
-        expect.fail('Should have thrown an error')
-      } catch (error) {
-        expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-        const validationError = error as FirestoreTypedValidationError
-        if (validationError.originalError instanceof Error) {
-          expect(validationError.originalError.message).toContain(
-            'Status must be either "active" or "inactive"',
-          )
-        } else {
-          expect(String(validationError.originalError)).toContain(
-            'Status must be either "active" or "inactive"',
-          )
-        }
-      }
+      const error = await catchError<FirestoreTypedValidationError>(() =>
+        collection.add(invalidUser),
+      )
+
+      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
+      expect(error.originalError).toBeInstanceOf(Error)
+      expect((error.originalError as Error).message).toContain(
+        'Status must be either "active" or "inactive"',
+      )
     })
 
     it('should wrap validation errors in FirestoreTypedValidationError', async () => {
@@ -245,13 +205,12 @@ describe('FirestoreTyped Validation', () => {
         createdAt: new Date(),
       }
 
-      try {
-        await collection.add(invalidUser as any)
-        expect.fail('Should have thrown an error')
-      } catch (error) {
-        expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-        expect((error as FirestoreTypedValidationError).message).toContain('Validation failed')
-      }
+      const error = await catchError<FirestoreTypedValidationError>(() =>
+        collection.add(invalidUser as any),
+      )
+
+      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
+      expect(error.message).toContain('Validation failed')
     })
   })
 

--- a/src/core/__tests__/zod/collection.zod.test.ts
+++ b/src/core/__tests__/zod/collection.zod.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { CollectionReference } from '../../collection'
+import { catchError } from '../../../__tests__/__helpers__/catch-error.helper'
 import type { FirestoreTypedOptionsProvider } from '../../../types/firestore-typed.types'
 import {
   createUserProfileValidator,
@@ -683,18 +684,15 @@ describe('CollectionReference with Zod validators', () => {
         permissions: [],
       }
 
-      try {
-        await userCollection.add(invalidUserProfile as any)
-        expect.fail('Should have thrown validation error')
-      } catch (error) {
-        expect(error).toBeDefined()
-        // Check that we got a FirestoreTypedValidationError with original Zod error
-        expect((error as any).name).toBe('FirestoreTypedValidationError')
-        expect((error as any).originalError).toBeDefined()
-        // Zod provides detailed error information in the original error
-        const originalError = (error as any).originalError
-        expect(originalError.message || originalError.toString()).toContain('min')
-      }
+      const error = await catchError<any>(() => userCollection.add(invalidUserProfile as any))
+
+      expect(error).toBeDefined()
+      // Check that we got a FirestoreTypedValidationError with original Zod error
+      expect(error.name).toBe('FirestoreTypedValidationError')
+      expect(error.originalError).toBeDefined()
+      // Zod provides detailed error information in the original error
+      const originalError = error.originalError
+      expect(originalError.message || originalError.toString()).toContain('min')
     })
   })
 })

--- a/src/errors/__tests__/unit/errors.unit.test.ts
+++ b/src/errors/__tests__/unit/errors.unit.test.ts
@@ -4,6 +4,7 @@ import {
   DocumentNotFoundError,
   DocumentAlreadyExistsError,
 } from '../../errors'
+import { catchError } from '../../../__tests__/__helpers__/catch-error.helper'
 
 describe('Error Classes', () => {
   describe('FirestoreTypedValidationError', () => {
@@ -63,19 +64,18 @@ describe('Error Classes', () => {
       if (originalCaptureStackTrace) Error.captureStackTrace = originalCaptureStackTrace
     })
 
-    it('should preserve all properties when thrown and caught', () => {
+    it('should preserve all properties when thrown and caught', async () => {
       const originalError = new Error('Type validation failed')
 
-      try {
+      const error = await catchError<FirestoreTypedValidationError>(() => {
         throw new FirestoreTypedValidationError(testMessage, testPath, originalError)
-      } catch (caught) {
-        expect(caught).toBeInstanceOf(FirestoreTypedValidationError)
-        const error = caught as FirestoreTypedValidationError
-        expect(error.message).toBe(testMessage)
-        expect(error.documentPath).toBe(testPath)
-        expect(error.originalError).toBe(originalError)
-        expect(error.name).toBe('FirestoreTypedValidationError')
-      }
+      })
+
+      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
+      expect(error.message).toBe(testMessage)
+      expect(error.documentPath).toBe(testPath)
+      expect(error.originalError).toBe(originalError)
+      expect(error.name).toBe('FirestoreTypedValidationError')
     })
 
     it('should handle different types of original errors', () => {
@@ -139,16 +139,15 @@ describe('Error Classes', () => {
       if (originalCaptureStackTrace) Error.captureStackTrace = originalCaptureStackTrace
     })
 
-    it('should preserve all properties when thrown and caught', () => {
-      try {
+    it('should preserve all properties when thrown and caught', async () => {
+      const error = await catchError<DocumentNotFoundError>(() => {
         throw new DocumentNotFoundError(testPath)
-      } catch (caught) {
-        expect(caught).toBeInstanceOf(DocumentNotFoundError)
-        const error = caught as DocumentNotFoundError
-        expect(error.message).toBe(`Document not found at path: ${testPath}`)
-        expect(error.documentPath).toBe(testPath)
-        expect(error.name).toBe('DocumentNotFoundError')
-      }
+      })
+
+      expect(error).toBeInstanceOf(DocumentNotFoundError)
+      expect(error.message).toBe(`Document not found at path: ${testPath}`)
+      expect(error.documentPath).toBe(testPath)
+      expect(error.name).toBe('DocumentNotFoundError')
     })
 
     it('should handle different document paths', () => {
@@ -213,16 +212,15 @@ describe('Error Classes', () => {
       if (originalCaptureStackTrace) Error.captureStackTrace = originalCaptureStackTrace
     })
 
-    it('should preserve all properties when thrown and caught', () => {
-      try {
+    it('should preserve all properties when thrown and caught', async () => {
+      const error = await catchError<DocumentAlreadyExistsError>(() => {
         throw new DocumentAlreadyExistsError(testPath)
-      } catch (caught) {
-        expect(caught).toBeInstanceOf(DocumentAlreadyExistsError)
-        const error = caught as DocumentAlreadyExistsError
-        expect(error.message).toBe(`Document already exists at path: ${testPath}`)
-        expect(error.documentPath).toBe(testPath)
-        expect(error.name).toBe('DocumentAlreadyExistsError')
-      }
+      })
+
+      expect(error).toBeInstanceOf(DocumentAlreadyExistsError)
+      expect(error.message).toBe(`Document already exists at path: ${testPath}`)
+      expect(error.documentPath).toBe(testPath)
+      expect(error.name).toBe('DocumentAlreadyExistsError')
     })
 
     it('should handle different document paths', () => {

--- a/src/utils/__tests__/unit/validator.unit.test.ts
+++ b/src/utils/__tests__/unit/validator.unit.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect } from 'vitest'
 import { validateData } from '../../validator'
 import { FirestoreTypedValidationError } from '../../../errors/errors'
+import { catchError } from '../../../__tests__/__helpers__/catch-error.helper'
 
 describe('Validator', () => {
   interface TestEntity {
@@ -84,7 +85,7 @@ describe('Validator', () => {
         expect(mockValidator).toHaveBeenCalledWith(inputData)
       })
 
-      it('should preserve original error in wrapped error', () => {
+      it('should preserve original error in wrapped error', async () => {
         const inputData = { invalid: 'data' }
         const originalError = new Error('Type validation failed')
 
@@ -92,19 +93,17 @@ describe('Validator', () => {
           throw originalError
         })
 
-        try {
-          validateData(inputData, testPath, mockValidator)
-          expect.fail('Expected error to be thrown')
-        } catch (error) {
-          expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-          const wrappedError = error as FirestoreTypedValidationError
-          expect(wrappedError.message).toBe('Validation failed')
-          expect(wrappedError.documentPath).toBe(testPath)
-          expect(wrappedError.originalError).toBe(originalError)
-        }
+        const wrappedError = await catchError<FirestoreTypedValidationError>(() =>
+          validateData(inputData, testPath, mockValidator),
+        )
+
+        expect(wrappedError).toBeInstanceOf(FirestoreTypedValidationError)
+        expect(wrappedError.message).toBe('Validation failed')
+        expect(wrappedError.documentPath).toBe(testPath)
+        expect(wrappedError.originalError).toBe(originalError)
       })
 
-      it('should handle string errors thrown by validator', () => {
+      it('should handle string errors thrown by validator', async () => {
         const inputData = { invalid: 'data' }
         const stringError = 'String error message'
 
@@ -113,17 +112,15 @@ describe('Validator', () => {
           throw stringError
         })
 
-        try {
-          validateData(inputData, testPath, mockValidator)
-          expect.fail('Expected error to be thrown')
-        } catch (error) {
-          expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-          const wrappedError = error as FirestoreTypedValidationError
-          expect(wrappedError.originalError).toBe(stringError)
-        }
+        const wrappedError = await catchError<FirestoreTypedValidationError>(() =>
+          validateData(inputData, testPath, mockValidator),
+        )
+
+        expect(wrappedError).toBeInstanceOf(FirestoreTypedValidationError)
+        expect(wrappedError.originalError).toBe(stringError)
       })
 
-      it('should handle object errors thrown by validator', () => {
+      it('should handle object errors thrown by validator', async () => {
         const inputData = { invalid: 'data' }
         const objectError = { code: 'VALIDATION_FAILED', details: 'Field missing' }
 
@@ -132,17 +129,15 @@ describe('Validator', () => {
           throw objectError
         })
 
-        try {
-          validateData(inputData, testPath, mockValidator)
-          expect.fail('Expected error to be thrown')
-        } catch (error) {
-          expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-          const wrappedError = error as FirestoreTypedValidationError
-          expect(wrappedError.originalError).toBe(objectError)
-        }
+        const wrappedError = await catchError<FirestoreTypedValidationError>(() =>
+          validateData(inputData, testPath, mockValidator),
+        )
+
+        expect(wrappedError).toBeInstanceOf(FirestoreTypedValidationError)
+        expect(wrappedError.originalError).toBe(objectError)
       })
 
-      it('should handle null/undefined errors thrown by validator', () => {
+      it('should handle null/undefined errors thrown by validator', async () => {
         const inputData = { invalid: 'data' }
 
         const nullValidator = vi.fn().mockImplementation(() => {
@@ -154,28 +149,24 @@ describe('Validator', () => {
           throw undefined
         })
 
-        try {
-          validateData(inputData, testPath, nullValidator)
-          expect.fail('Expected error to be thrown')
-        } catch (error) {
-          expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-          const wrappedError = error as FirestoreTypedValidationError
-          expect(wrappedError.originalError).toBe(null)
-        }
+        const nullWrappedError = await catchError<FirestoreTypedValidationError>(() =>
+          validateData(inputData, testPath, nullValidator),
+        )
 
-        try {
-          validateData(inputData, testPath, undefinedValidator)
-          expect.fail('Expected error to be thrown')
-        } catch (error) {
-          expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-          const wrappedError = error as FirestoreTypedValidationError
-          expect(wrappedError.originalError).toBe(undefined)
-        }
+        expect(nullWrappedError).toBeInstanceOf(FirestoreTypedValidationError)
+        expect(nullWrappedError.originalError).toBe(null)
+
+        const undefinedWrappedError = await catchError<FirestoreTypedValidationError>(() =>
+          validateData(inputData, testPath, undefinedValidator),
+        )
+
+        expect(undefinedWrappedError).toBeInstanceOf(FirestoreTypedValidationError)
+        expect(undefinedWrappedError.originalError).toBe(undefined)
       })
     })
 
     describe('Path Handling', () => {
-      it('should include correct document path in error', () => {
+      it('should include correct document path in error', async () => {
         const paths = [
           'users/user1',
           'posts/post123',
@@ -183,23 +174,21 @@ describe('Validator', () => {
           'organizations/org1/projects/project2/tasks/task789',
         ]
 
-        paths.forEach((path) => {
+        for (const path of paths) {
           const mockValidator = vi.fn().mockImplementation(() => {
             throw new Error('Validation error')
           })
 
-          try {
-            validateData({}, path, mockValidator)
-            expect.fail('Expected error to be thrown')
-          } catch (error) {
-            expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-            const wrappedError = error as FirestoreTypedValidationError
-            expect(wrappedError.documentPath).toBe(path)
-          }
-        })
+          const wrappedError = await catchError<FirestoreTypedValidationError>(() =>
+            validateData({}, path, mockValidator),
+          )
+
+          expect(wrappedError).toBeInstanceOf(FirestoreTypedValidationError)
+          expect(wrappedError.documentPath).toBe(path)
+        }
       })
 
-      it('should handle empty and special character paths', () => {
+      it('should handle empty and special character paths', async () => {
         const specialPaths = [
           '',
           '/',
@@ -211,20 +200,18 @@ describe('Validator', () => {
           'users/user.with.dots',
         ]
 
-        specialPaths.forEach((path) => {
+        for (const path of specialPaths) {
           const mockValidator = vi.fn().mockImplementation(() => {
             throw new Error('Validation error')
           })
 
-          try {
-            validateData({}, path, mockValidator)
-            expect.fail('Expected error to be thrown')
-          } catch (error) {
-            expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-            const wrappedError = error as FirestoreTypedValidationError
-            expect(wrappedError.documentPath).toBe(path)
-          }
-        })
+          const wrappedError = await catchError<FirestoreTypedValidationError>(() =>
+            validateData({}, path, mockValidator),
+          )
+
+          expect(wrappedError).toBeInstanceOf(FirestoreTypedValidationError)
+          expect(wrappedError.documentPath).toBe(path)
+        }
       })
     })
 


### PR DESCRIPTION
## Summary

Closes #83

Re-enables `vitest/no-conditional-expect` (opted out in #82) by rewriting all 58 `expect` calls inside catch blocks across 5 test files into linear assertions.

## Changes

### New `catchError` helper (`src/__tests__/__helpers__/catch-error.helper.ts`)

Runs a function that is expected to throw (or reject), returns the thrown error, and fails the test if nothing is thrown. This removes try/catch from test bodies so assertions become fully linear. The helper itself uses no `expect` inside conditionals.

```typescript
const error = await catchError<FirestoreTypedValidationError>(() =>
  collection.add(null as any),
)
expect(error).toBeInstanceOf(FirestoreTypedValidationError)
expect(error.originalError).toBeInstanceOf(Error)
```

### Rewritten test files (58 sites)

| File | Sites | Notes |
|---|---|---|
| validation.integration.test.ts | 23 | |
| validator.unit.test.ts | 16 | `forEach` loops converted to `for...of` + await |
| errors.unit.test.ts | 13 | kept the "thrown and caught" intent via `catchError` |
| collection.zod.test.ts | 4 | |
| firestore-typed.integration.test.ts | 2 | |

### Stricter assertions (intentional)

The old defensive `if (originalError instanceof Error) {...} else {...}` branches were collapsed into `expect(error.originalError).toBeInstanceOf(Error)` plus direct message assertions. The validators in these tests (hand-written, typia, zod) always throw `Error` subclasses, so this strengthens the assertions: previously either branch partially verified; now the `Error` type is mandatory.

### Rule re-enabled

Removed `'vitest/no-conditional-expect': 'off'` from `eslint.config.mjs`; the plugin's recommended setting now applies.

## Verification

- ✅ `npm run lint` — clean with the rule active
- ✅ `npm test` — all 240 tests pass (test count unchanged)
- ✅ `npm run typecheck` / `format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)