### PR TITLE
docs: CHANGELOG for v0.6.0, README requirements section, version bump

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,26 @@
 このフォーマットは[Keep a Changelog](https://keepachangelog.com/en/1.0.0/)に基づいており、
 このプロジェクトは[セマンティックバージョニング](https://semver.org/spec/v2.0.0.html)に準拠しています。
 
+## [0.6.0] - 2026-07-10
+
+### 追加
+
+- **firebase-admin v14サポート**: peer dependencyの範囲を`^13.5.0 || ^14.0.0`に拡大
+  - @google-cloud/firestore 8に対して、実Firestoreエミュレータでの読み書きテストを含めて検証済み
+- **typia v10〜v12サポート**: peer dependencyの範囲を`^9.7.2`から`>=9.7.2 <13`に拡大
+  - typia v13はTypeScript 7 + ttsc専用のため除外(issue #85参照)
+
+### 変更
+
+- **破壊的変更**: Node.js 22以上が必須になりました(`engines`フィールドを追加)。
+  Node.js 20は2026年4月にEOLを迎えたためサポート対象外です
+- tsdown 0.22のデフォルトに従いESMビルド成果物のファイル名を変更
+  (`dist/index.js` → `dist/index.mjs`、`dist/index.d.ts` → `dist/index.d.mts`)。
+  エントリポイントは`exports`マップ経由で解決されるため利用者側の対応は不要です
+- CIのテスト対象をNode.js 22.x、24.x、26.xに変更
+- **開発依存関係**: TypeScript 6.0、typia 12.1、tsdown 0.22、vitest 4、
+  ESLint 10、firebase-admin 14
+
 ## [0.5.5] - 2025-10-07
 
 ### 修正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-07-10
+
+### Added
+
+- **firebase-admin v14 support**: peer dependency range widened to `^13.5.0 || ^14.0.0`
+  - Verified against @google-cloud/firestore 8 including real Firestore emulator I/O tests
+- **typia v10–v12 support**: peer dependency range widened from `^9.7.2` to `>=9.7.2 <13`
+  - typia v13 is excluded because it requires TypeScript 7 + ttsc (see issue #85)
+
+### Changed
+
+- **BREAKING**: Node.js >= 22 is now required (`engines` field added). Node.js 20 reached
+  end-of-life in April 2026 and is no longer supported
+- ESM build artifacts renamed following tsdown 0.22 defaults
+  (`dist/index.js` → `dist/index.mjs`, `dist/index.d.ts` → `dist/index.d.mts`).
+  Consumers resolve entry points via the `exports` map, so no action is required
+- CI now tests on Node.js 22.x, 24.x, and 26.x
+- **Development dependencies**: TypeScript 6.0, typia 12.1, tsdown 0.22, vitest 4,
+  ESLint 10, firebase-admin 14
+
 ## [0.5.5] - 2025-10-07
 
 ### Fixed

--- a/README.ja.md
+++ b/README.ja.md
@@ -68,11 +68,17 @@ await users.doc('123').set({
 
 ## インストール
 
-これはワークスペース内のプライベートnpmパッケージです：
-
 ```bash
 npm install @info-lounge/firestore-typed
 ```
+
+### 動作要件
+
+- **Node.js**: 22以上
+- **firebase-admin**: `^13.5.0 || ^14.0.0`(peer dependency)
+- **バリデーションライブラリ**(peer dependency、少なくとも一方を選択):
+  - typia: `>=9.7.2 <13`(v13はTypeScript 7 + ttsc専用のため現時点では未サポート)
+  - zod: `^4.0.17`
 
 ### 依存関係
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,17 @@ await users.doc('123').set({
 
 ## Installation
 
-This is a private npm package within the workspace:
-
 ```bash
 npm install @info-lounge/firestore-typed
 ```
+
+### Requirements
+
+- **Node.js**: >= 22
+- **firebase-admin**: `^13.5.0 || ^14.0.0` (peer dependency)
+- **Validation library** (peer dependency, choose at least one):
+  - typia: `>=9.7.2 <13` (v13 requires TypeScript 7 + ttsc, which is not supported yet)
+  - zod: `^4.0.17`
 
 ### Dependencies
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@info-lounge/firestore-typed",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "Type-safe, low-level wrapper for Firebase Firestore with enhanced validation and developer experience",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

Documentation freshness pass after today's dependency work. The CHANGELOG had not been updated since 0.5.5 (2025-10-07), while all of today's changes are user-visible enough to require an entry before the next release (the release workflow extracts GitHub Release notes from CHANGELOG.md).

## Changes

### CHANGELOG.md / CHANGELOG.ja.md — new `[0.6.0]` section

- **Added**: firebase-admin v14 support (`^13.5.0 || ^14.0.0`), typia v10–v12 support (`>=9.7.2 <13`)
- **Changed (BREAKING)**: Node.js >= 22 required (`engines` added; Node 20 is EOL)
- **Changed**: ESM dist filenames follow tsdown 0.22 defaults (`.mjs` / `.d.mts`, transparent via `exports` map), CI matrix 22/24/26, dev dependency upgrades (TS 6.0, vitest 4, ESLint 10, etc.)

### README.md / README.ja.md

- New **Requirements** section: Node >= 22 and peer dependency ranges, so users don't need to inspect package.json
- Removed stale "This is a private npm package within the workspace" wording — the package is published publicly on npm

### package.json

- Version bump `0.5.5` → `0.6.0`. The minor bump (rather than patch) reflects the Node 20 support drop, following 0.x semver conventions for breaking changes. The release to npm will trigger automatically when develop is merged to main.

## Not changed (verified as current)

- CLAUDE.md: CI Node versions were already updated in #81; the ts-patch note is still accurate for typia v9–v12 + TS 5/6
- README ts-patch setup instructions: still valid for the supported version range (TS7/typia v13 rewrite is tracked in #85)

🤖 Generated with [Claude Code](https://claude.com/claude-code)