### PR TITLE
refactor(tests): follow-up cleanups for the error-assertion rewrite

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,8 @@ export default tseslint.config(
     },
     rules: {
       ...vitestPlugin.configs.recommended.rules,
+      // Recognize shared assertion helpers (e.g. expectValidationErrorContaining) as assertions
+      'vitest/expect-expect': ['error', { assertFunctionNames: ['expect', 'expect*'] }],
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',

--- a/src/__tests__/validation.integration.test.ts
+++ b/src/__tests__/validation.integration.test.ts
@@ -59,6 +59,17 @@ describe('FirestoreTyped Validation', () => {
     return obj as UserEntity
   }
 
+  async function expectValidationErrorContaining(
+    fn: () => unknown,
+    messagePart: string,
+  ): Promise<void> {
+    const error = await catchError<FirestoreTypedValidationError>(fn)
+
+    expect(error).toBeInstanceOf(FirestoreTypedValidationError)
+    expect(error.originalError).toBeInstanceOf(Error)
+    expect((error.originalError as Error).message).toContain(messagePart)
+  }
+
   describe('Write Validation', () => {
     let db: ReturnType<typeof getFirestoreTyped>
     let collection: ReturnType<typeof db.collection<UserEntity>>
@@ -84,23 +95,17 @@ describe('FirestoreTyped Validation', () => {
     })
 
     it('should reject null data', async () => {
-      const error = await catchError<FirestoreTypedValidationError>(() =>
-        collection.add(null as any),
+      await expectValidationErrorContaining(
+        () => collection.add(null as any),
+        'Data must be an object',
       )
-
-      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-      expect(error.originalError).toBeInstanceOf(Error)
-      expect((error.originalError as Error).message).toContain('Data must be an object')
     })
 
     it('should reject undefined data', async () => {
-      const error = await catchError<FirestoreTypedValidationError>(() =>
-        collection.add(undefined as any),
+      await expectValidationErrorContaining(
+        () => collection.add(undefined as any),
+        'Data must be an object',
       )
-
-      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-      expect(error.originalError).toBeInstanceOf(Error)
-      expect((error.originalError as Error).message).toContain('Data must be an object')
     })
 
     it('should reject data with missing required fields', async () => {
@@ -109,13 +114,10 @@ describe('FirestoreTyped Validation', () => {
         // missing email, age, status, createdAt
       }
 
-      const error = await catchError<FirestoreTypedValidationError>(() =>
-        collection.add(invalidUser as any),
+      await expectValidationErrorContaining(
+        () => collection.add(invalidUser as any),
+        'Email is required',
       )
-
-      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-      expect(error.originalError).toBeInstanceOf(Error)
-      expect((error.originalError as Error).message).toContain('Email is required')
     })
 
     it('should reject data with invalid name length', async () => {
@@ -127,13 +129,8 @@ describe('FirestoreTyped Validation', () => {
         createdAt: new Date(),
       }
 
-      const error = await catchError<FirestoreTypedValidationError>(() =>
-        collection.add(invalidUser),
-      )
-
-      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-      expect(error.originalError).toBeInstanceOf(Error)
-      expect((error.originalError as Error).message).toContain(
+      await expectValidationErrorContaining(
+        () => collection.add(invalidUser),
         'Name must be between 2 and 50 characters',
       )
     })
@@ -147,13 +144,8 @@ describe('FirestoreTyped Validation', () => {
         createdAt: new Date(),
       }
 
-      const error = await catchError<FirestoreTypedValidationError>(() =>
-        collection.add(invalidUser),
-      )
-
-      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-      expect(error.originalError).toBeInstanceOf(Error)
-      expect((error.originalError as Error).message).toContain(
+      await expectValidationErrorContaining(
+        () => collection.add(invalidUser),
         'Email must be a valid email address',
       )
     })
@@ -167,13 +159,10 @@ describe('FirestoreTyped Validation', () => {
         createdAt: new Date(),
       }
 
-      const error = await catchError<FirestoreTypedValidationError>(() =>
-        collection.add(invalidUser),
+      await expectValidationErrorContaining(
+        () => collection.add(invalidUser),
+        'Age must be between 0 and 120',
       )
-
-      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-      expect(error.originalError).toBeInstanceOf(Error)
-      expect((error.originalError as Error).message).toContain('Age must be between 0 and 120')
     })
 
     it('should reject data with invalid status', async () => {
@@ -185,13 +174,8 @@ describe('FirestoreTyped Validation', () => {
         createdAt: new Date(),
       }
 
-      const error = await catchError<FirestoreTypedValidationError>(() =>
-        collection.add(invalidUser),
-      )
-
-      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
-      expect(error.originalError).toBeInstanceOf(Error)
-      expect((error.originalError as Error).message).toContain(
+      await expectValidationErrorContaining(
+        () => collection.add(invalidUser),
         'Status must be either "active" or "inactive"',
       )
     })

--- a/src/core/__tests__/zod/collection.zod.test.ts
+++ b/src/core/__tests__/zod/collection.zod.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { CollectionReference } from '../../collection'
+import { FirestoreTypedValidationError } from '../../../errors/errors'
 import { catchError } from '../../../__tests__/__helpers__/catch-error.helper'
 import type { FirestoreTypedOptionsProvider } from '../../../types/firestore-typed.types'
 import {
@@ -684,15 +685,15 @@ describe('CollectionReference with Zod validators', () => {
         permissions: [],
       }
 
-      const error = await catchError<any>(() => userCollection.add(invalidUserProfile as any))
+      const error = await catchError<FirestoreTypedValidationError>(() =>
+        userCollection.add(invalidUserProfile as any),
+      )
 
-      expect(error).toBeDefined()
       // Check that we got a FirestoreTypedValidationError with original Zod error
-      expect(error.name).toBe('FirestoreTypedValidationError')
-      expect(error.originalError).toBeDefined()
+      expect(error).toBeInstanceOf(FirestoreTypedValidationError)
       // Zod provides detailed error information in the original error
-      const originalError = error.originalError
-      expect(originalError.message || originalError.toString()).toContain('min')
+      expect(error.originalError).toBeInstanceOf(Error)
+      expect((error.originalError as Error).message).toContain('min')
     })
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #86. These /simplify review fixes were pushed to the #86 branch right after it was merged, so they never landed on develop — this PR cherry-picks that commit (net −13 lines).

## Changes

- **collection.zod.test.ts**: type `catchError<FirestoreTypedValidationError>` instead of `<any>`, replacing name-string checks (`error.name === 'FirestoreTypedValidationError'`) with `instanceof` assertions
- **validation.integration.test.ts**: extract an `expectValidationErrorContaining` helper absorbing the 7 identical instanceof+message assertion blocks
- **eslint.config.mjs**: configure `vitest/expect-expect` with `assertFunctionNames: ['expect', 'expect*']` so shared assertion helpers are recognized as assertions

## Verification

- ✅ `npm run lint` — clean (including the re-enabled `vitest/no-conditional-expect`)
- ✅ `npm test` — all 240 tests pass
- ✅ `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)