### PR TITLE
chore(ci): migrate npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
       - name: Get package version
@@ -66,10 +65,11 @@ jobs:
       - name: Build package
         run: npm run build
 
+      # Publishes via npm Trusted Publishing (OIDC) — no token needed.
+      # Requires the trusted publisher configured on npmjs.com for this repo/workflow
+      # and the id-token: write permission declared above.
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Create Git tag
         run: |

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/InfoLoungeLLC/firestore-typed.git"
+    "url": "git+https://github.com/InfoLoungeLLC/firestore-typed.git"
   },
   "bugs": {
     "url": "https://github.com/InfoLoungeLLC/firestore-typed/issues"


### PR DESCRIPTION
## Summary

The v0.6.0 release run failed at the `Publish to npm` step with an E404 on PUT — the classic symptom of an expired/revoked `NPM_TOKEN` (the last successful release was 2025-10; npm's late-2025 security changes revoked classic tokens and capped granular token lifetimes at 90 days). Rather than renewing a token that will expire again, this migrates publishing to npm Trusted Publishing (OIDC).

The trusted publisher for this repo/workflow has been configured on npmjs.com (org `InfoLoungeLLC`, repo `firestore-typed`, workflow `release.yml`).

## Changes

### .github/workflows/release.yml
- Remove `NODE_AUTH_TOKEN` from the publish step — `npm publish` authenticates via the GitHub Actions OIDC token (`permissions: id-token: write` was already declared)
- Remove `registry-url` from `setup-node` — leaving it writes an `.npmrc` referencing `${NODE_AUTH_TOKEN}`, which errors when the variable is undefined (known trusted-publishing pitfall)
- Runner npm: Node 24 bundles npm 11.7 ≥ the required 11.5.1, no extra install step needed

### package.json
- Normalize `repository.url` to `git+https://...` — npm warned and auto-corrected this during the failed publish, and provenance validation checks that the repository URL matches

## Release recovery

After this merges to develop, a small develop → main PR re-triggers the release workflow: the 0.6.0 version/tag checks still pass (nothing was published or tagged), and publish proceeds via OIDC with provenance.

Post-release hardening (manual, on npmjs.com / GitHub):
- Enable "Require two-factor authentication and disallow tokens" (does not affect trusted publishers)
- Delete the now-unused `NPM_TOKEN` repository secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)