### PR TITLE
Release v0.6.0 (retry with OIDC publishing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
       - name: Get package version
@@ -66,10 +65,11 @@ jobs:
       - name: Build package
         run: npm run build
 
+      # Publishes via npm Trusted Publishing (OIDC) — no token needed.
+      # Requires the trusted publisher configured on npmjs.com for this repo/workflow
+      # and the id-token: write permission declared above.
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Create Git tag
         run: |

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/InfoLoungeLLC/firestore-typed.git"
+    "url": "git+https://github.com/InfoLoungeLLC/firestore-typed.git"
   },
   "bugs": {
     "url": "https://github.com/InfoLoungeLLC/firestore-typed/issues"


### PR DESCRIPTION
## Release v0.6.0 — retry

The first release attempt (#89) passed all quality gates but failed at `npm publish` due to an expired `NPM_TOKEN`. Publishing has since been migrated to npm Trusted Publishing / OIDC (#90), and the trusted publisher is configured on npmjs.com.

Merging this PR re-runs the release workflow on main: the 0.6.0 version/tag checks still pass (nothing was published or tagged in the failed attempt), and publish proceeds via OIDC with provenance attestations.

### Delta since #89

- #90 — chore(ci): migrate npm publish to Trusted Publishing (OIDC) + normalize `repository.url`

See #89 for the full 0.6.0 release notes (Node >= 22 requirement, firebase-admin v14 / typia v12 support, TypeScript 6.0, etc.) — the CHANGELOG `[0.6.0]` section is unchanged.

### Post-merge checklist (manual)

- [ ] Verify the release workflow publishes 0.6.0 and creates the `v0.6.0` tag + GitHub Release
- [ ] On npmjs.com: enable "Require two-factor authentication and disallow tokens"
- [ ] Delete the `NPM_TOKEN` repository secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)