### PR TITLE
docs: CHANGELOG for v0.6.1, version bump

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,17 @@
 このフォーマットは[Keep a Changelog](https://keepachangelog.com/en/1.0.0/)に基づいており、
 このプロジェクトは[セマンティックバージョニング](https://semver.org/spec/v2.0.0.html)に準拠しています。
 
+## [0.6.1] - 2026-07-10
+
+### 変更
+
+- **公開フロー**: npmへのリリースを長期アクセストークンからnpm Trusted Publishing(OIDC)に移行し、
+  provenance(来歴証明)を付与するようにしました
+- package.jsonの`repository.url`を正規形の`git+https://`形式に修正
+  (従来はnpmがpublish時に自動補正していました)
+
+ランタイムコードの変更はありません — 公開物は0.6.0と機能的に同一です。
+
 ## [0.6.0] - 2026-07-10
 
 ### 追加

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-07-10
+
+### Changed
+
+- **Publishing**: npm releases are now published via npm Trusted Publishing (OIDC)
+  instead of long-lived access tokens, with provenance attestations attached
+- Normalized `repository.url` in package.json to the canonical `git+https://` form
+  (npm previously auto-corrected this at publish time)
+
+No runtime code changes — the published package is functionally identical to 0.6.0.
+
 ## [0.6.0] - 2026-07-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@info-lounge/firestore-typed",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Type-safe, low-level wrapper for Firebase Firestore with enhanced validation and developer experience",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

Prepares the v0.6.1 patch release, whose purpose is to exercise the new OIDC publishing path (#90) end to end before it is needed for a real release. No runtime code changes — the release content is the publishing migration itself plus the `repository.url` normalization.

## Changes

- `package.json`: 0.6.0 → 0.6.1
- `CHANGELOG.md` / `CHANGELOG.ja.md`: `[0.6.1]` section

## Release plan

1. Merge this into develop
2. develop → main release PR → merging it runs release.yml, which publishes via npm Trusted Publishing (OIDC) for the first time
3. Verify: publish succeeds without `NODE_AUTH_TOKEN`, and provenance attestations appear on the npm package page
4. After verification: enable "disallow tokens" on npmjs.com and delete the `NPM_TOKEN` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)