### PR TITLE
Release v0.6.1 — first OIDC publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
       - name: Get package version
@@ -66,10 +65,11 @@ jobs:
       - name: Build package
         run: npm run build
 
+      # Publishes via npm Trusted Publishing (OIDC) — no token needed.
+      # Requires the trusted publisher configured on npmjs.com for this repo/workflow
+      # and the id-token: write permission declared above.
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Create Git tag
         run: |

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,17 @@
 このフォーマットは[Keep a Changelog](https://keepachangelog.com/en/1.0.0/)に基づいており、
 このプロジェクトは[セマンティックバージョニング](https://semver.org/spec/v2.0.0.html)に準拠しています。
 
+## [0.6.1] - 2026-07-10
+
+### 変更
+
+- **公開フロー**: npmへのリリースを長期アクセストークンからnpm Trusted Publishing(OIDC)に移行し、
+  provenance(来歴証明)を付与するようにしました
+- package.jsonの`repository.url`を正規形の`git+https://`形式に修正
+  (従来はnpmがpublish時に自動補正していました)
+
+ランタイムコードの変更はありません — 公開物は0.6.0と機能的に同一です。
+
 ## [0.6.0] - 2026-07-10
 
 ### 追加

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-07-10
+
+### Changed
+
+- **Publishing**: npm releases are now published via npm Trusted Publishing (OIDC)
+  instead of long-lived access tokens, with provenance attestations attached
+- Normalized `repository.url` in package.json to the canonical `git+https://` form
+  (npm previously auto-corrected this at publish time)
+
+No runtime code changes — the published package is functionally identical to 0.6.0.
+
 ## [0.6.0] - 2026-07-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@info-lounge/firestore-typed",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Type-safe, low-level wrapper for Firebase Firestore with enhanced validation and developer experience",
   "type": "module",
   "main": "dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/InfoLoungeLLC/firestore-typed.git"
+    "url": "git+https://github.com/InfoLoungeLLC/firestore-typed.git"
   },
   "bugs": {
     "url": "https://github.com/InfoLoungeLLC/firestore-typed/issues"


### PR DESCRIPTION
## Release v0.6.1

Patch release exercising npm Trusted Publishing (OIDC) end to end. No runtime code changes.

### Contents

- #90 — chore(ci): migrate npm publish to Trusted Publishing (OIDC); normalize `repository.url`
- #101 — version bump + CHANGELOG `[0.6.1]`

### What merging this does

Runs release.yml on main with the OIDC-ready workflow: quality gates → `npm publish` authenticated via the GitHub Actions OIDC token (no `NODE_AUTH_TOKEN`) → `v0.6.1` tag → GitHub Release.

### Post-merge verification

- [ ] Publish step succeeds via OIDC
- [ ] Provenance attestation visible on the npm package page
- [ ] Then: enable "Require 2FA and disallow tokens" on npmjs.com, delete the `NPM_TOKEN` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)