### PR TITLE
ci: run emulator tests in a dedicated CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,28 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  emulator-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: 'npm'
+
+      - name: Setup Java (required by the Firestore emulator)
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run emulator tests
+        run: npx --yes firebase-tools@15 emulators:exec --project demo-firestore-typed --only firestore 'npm run test:emulator'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,5 +181,5 @@ Primary support for typia validators, but accepts any function with signature `(
 
 ### CI/CD Notes
 - GitHub Actions runs tests on Node.js 22.x, 24.x, and 26.x
-- Emulator tests are run separately in CI pipeline
+- Emulator tests run in a dedicated CI job via `firebase emulators:exec` (separate from the Node-matrix test job)
 - Coverage reports are uploaded to Codecov


### PR DESCRIPTION
## Summary

Closes #99.

Emulator tests (`*.emulator.test.ts`) were excluded from the default vitest suite and never executed in CI — `ci.yml` only ran `npm run test:coverage`. Bugs that only reproduce against real Firestore (the #92 race, the #93 query mismatch) were invisible to CI. CLAUDE.md also incorrectly claimed emulator tests ran in CI.

## Changes

- **ci.yml**: new `emulator-test` job — Node 24 + Temurin 21 (the Firestore emulator requires Java), `npm ci`, then
  `npx --yes firebase-tools@15 emulators:exec --project demo-firestore-typed --only firestore 'npm run test:emulator'`
  (`emulators:exec` starts the emulator, runs the script, and shuts everything down)
- **CLAUDE.md**: CI note corrected to describe the dedicated job

## Verification

- ✅ The exact `emulators:exec` command runs green locally (4 emulator tests pass)
- The job runs on this PR itself — check the `emulator-test` check below

## Notes

- Runs once (not per Node-matrix entry) — emulator behavior doesn't vary by Node version, and it keeps CI time down
- `firebase-tools` is pinned to major 15 via npx rather than added to devDependencies, keeping the default install light
- Landing this before #92/#93/#94 so their regression tests are CI-enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)