### PR TITLE
fix: make failIfExists atomic using DocumentReference.create()

### DIFF
--- a/src/core/__tests__/emulator/firestore-typed.emulator.test.ts
+++ b/src/core/__tests__/emulator/firestore-typed.emulator.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
 import { FirestoreTyped } from '../../firestore-typed'
+import { DocumentAlreadyExistsError } from '../../../errors/errors'
 import {
   setupEmulator,
   teardownEmulator,
@@ -83,6 +84,51 @@ describe('FirestoreTyped Core Class (Emulator)', () => {
       } finally {
         // Clean up: delete the documents we created
         await Promise.all([docRef1.delete(), docRef2.delete()])
+      }
+    })
+  })
+
+  describe('failIfExists atomicity', () => {
+    it('should allow exactly one of two concurrent failIfExists writes to succeed', async () => {
+      const validator = createSimpleTestEntityValidator()
+      const uniqueCollectionName = `test-atomic-${Date.now()}-${Math.random()}`
+      const collection = firestoreTyped.collection(uniqueCollectionName, validator)
+      const docRef = collection.doc('contested-doc')
+
+      const testData = createSimpleTestEntity({ id: '123', name: 'First Writer' })
+
+      try {
+        const results = await Promise.allSettled([
+          docRef.set(testData, { failIfExists: true }),
+          docRef.set(testData, { failIfExists: true }),
+        ])
+
+        const fulfilled = results.filter((r) => r.status === 'fulfilled')
+        const rejected = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+
+        expect(fulfilled).toHaveLength(1)
+        expect(rejected).toHaveLength(1)
+        expect(rejected[0].reason).toBeInstanceOf(DocumentAlreadyExistsError)
+      } finally {
+        await docRef.delete()
+      }
+    })
+
+    it('should throw DocumentAlreadyExistsError for an existing document', async () => {
+      const validator = createSimpleTestEntityValidator()
+      const uniqueCollectionName = `test-exists-${Date.now()}-${Math.random()}`
+      const collection = firestoreTyped.collection(uniqueCollectionName, validator)
+      const docRef = collection.doc('existing-doc')
+
+      const testData = createSimpleTestEntity({ id: '123', name: 'Original' })
+      await docRef.set(testData)
+
+      try {
+        await expect(docRef.set(testData, { failIfExists: true })).rejects.toThrow(
+          DocumentAlreadyExistsError,
+        )
+      } finally {
+        await docRef.delete()
       }
     })
   })

--- a/src/core/__tests__/unit/document.unit.test.ts
+++ b/src/core/__tests__/unit/document.unit.test.ts
@@ -54,6 +54,7 @@ describe('DocumentReference', () => {
       firestore: {},
       get: vi.fn(),
       set: vi.fn(),
+      create: vi.fn(),
       delete: vi.fn(),
       update: vi.fn(),
     }
@@ -241,33 +242,38 @@ describe('DocumentReference', () => {
     })
 
     describe('failIfExists option', () => {
-      it('should check existence when failIfExists is true', async () => {
-        mockFirebaseDoc.get.mockResolvedValue({
-          exists: false,
-          id: 'test-id',
-          ref: mockFirebaseDoc,
-          data: () => undefined,
-        })
+      it('should write atomically via create() when failIfExists is true', async () => {
+        mockFirebaseDoc.create.mockResolvedValue(undefined)
 
         await docRef.set(testData, { failIfExists: true })
 
-        expect(mockFirebaseDoc.get).toHaveBeenCalled()
-        expect(mockFirebaseDoc.set).toHaveBeenCalledWith(testData)
+        expect(mockFirebaseDoc.create).toHaveBeenCalledWith(testData)
+        expect(mockFirebaseDoc.set).not.toHaveBeenCalled()
+        expect(mockFirebaseDoc.get).not.toHaveBeenCalled()
       })
 
       it('should throw DocumentAlreadyExistsError when document exists', async () => {
-        mockFirebaseDoc.get.mockResolvedValue({
-          exists: true,
-          id: 'test-id',
-          ref: mockFirebaseDoc,
-          data: () => testData,
-        })
+        // gRPC ALREADY_EXISTS error as thrown by Firestore's create()
+        const alreadyExistsError = Object.assign(
+          new Error('6 ALREADY_EXISTS: Document already exists'),
+          {
+            code: 6,
+          },
+        )
+        mockFirebaseDoc.create.mockRejectedValue(alreadyExistsError)
 
         await expect(docRef.set(testData, { failIfExists: true })).rejects.toThrow(
           DocumentAlreadyExistsError,
         )
 
         expect(mockFirebaseDoc.set).not.toHaveBeenCalled()
+      })
+
+      it('should rethrow non-ALREADY_EXISTS errors from create() unchanged', async () => {
+        const permissionError = Object.assign(new Error('7 PERMISSION_DENIED'), { code: 7 })
+        mockFirebaseDoc.create.mockRejectedValue(permissionError)
+
+        await expect(docRef.set(testData, { failIfExists: true })).rejects.toThrow(permissionError)
       })
     })
   })

--- a/src/core/document.ts
+++ b/src/core/document.ts
@@ -10,6 +10,18 @@ import type {
   FirestoreTypedOptionsProvider,
 } from '../types/firestore-typed.types'
 
+/** gRPC status code returned by Firestore when create() targets an existing document */
+const GRPC_ALREADY_EXISTS = 6
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === GRPC_ALREADY_EXISTS
+  )
+}
+
 /**
  * Wrapper for Firestore DocumentReference with type safety and validation
  */
@@ -78,19 +90,25 @@ export class DocumentReference<T extends SerializedDocumentData> {
     const globalOptions = this.firestoreTyped.getOptions()
     const validateOnWrite = options?.validateOnWrite ?? globalOptions.validateOnWrite
 
-    // Check if document already exists when failIfExists is true
-    if (options?.failIfExists) {
-      const snapshot = await this.ref.get()
-      if (snapshot.exists) {
-        throw new DocumentAlreadyExistsError(this.path)
-      }
-    }
-
     // Validate data first
     const validatedData = validateOnWrite ? validateData<T>(data, this.path, this.validator) : data
 
     // Deserialize data before writing to Firestore
     const deserializedData = deserializeFirestoreTypes(validatedData, this.ref.firestore)
+
+    if (options?.failIfExists) {
+      // create() enforces non-existence atomically on the server,
+      // unlike a read-then-write which is open to races
+      try {
+        await this.ref.create(deserializedData)
+      } catch (error) {
+        if (isAlreadyExistsError(error)) {
+          throw new DocumentAlreadyExistsError(this.path)
+        }
+        throw error
+      }
+      return
+    }
 
     await this.ref.set(deserializedData)
   }


### PR DESCRIPTION
## Summary

Closes #92 (High severity, from the 2026-07-10 external code review).

`set(data, { failIfExists: true })` checked existence with `get()` and then wrote with a plain `set()`. The check-then-write is not atomic: two concurrent calls could both pass the check and both fulfill (reproduced on the emulator by the reviewer, and now by a regression test in this PR).

## Changes

- **src/core/document.ts**: when `failIfExists` is set, write with `this.ref.create()` — Firestore enforces non-existence atomically on the server. The resulting gRPC `ALREADY_EXISTS` (code 6) error is translated to `DocumentAlreadyExistsError`; other errors propagate unchanged.
- **Unit tests**: rewritten for the `create()` path (atomic write, error translation, non-ALREADY_EXISTS passthrough)
- **Emulator tests**: new `failIfExists atomicity` suite —
  - two concurrent `failIfExists` writes → exactly 1 fulfilled, 1 rejected with `DocumentAlreadyExistsError` (fails on the old implementation)
  - plain existing-document case still throws `DocumentAlreadyExistsError`

## Behavior note

Validation now runs before the existence check (it must — the data is needed for `create()`). Invalid data targeting an existing document now throws `FirestoreTypedValidationError` instead of `DocumentAlreadyExistsError`. Also saves one read per `failIfExists` write.

## Verification

- ✅ `npm test` — 241 tests pass
- ✅ `npm run test:emulator` — 6 tests pass (via `firebase emulators:exec`, same command as the new CI job from #103)
- ✅ `npm run typecheck` / `lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)