### PR TITLE
fix: deserialize where() and cursor values so special-type queries match

### DIFF
--- a/src/core/__tests__/emulator/firestore-typed.emulator.test.ts
+++ b/src/core/__tests__/emulator/firestore-typed.emulator.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
 import { FirestoreTyped } from '../../firestore-typed'
 import { DocumentAlreadyExistsError } from '../../../errors/errors'
+import type {
+  SerializedGeoPoint,
+  SerializedDocumentReference,
+} from '../../../utils/firestore-converter'
 import {
   setupEmulator,
   teardownEmulator,
@@ -127,6 +131,50 @@ describe('FirestoreTyped Core Class (Emulator)', () => {
         await expect(docRef.set(testData, { failIfExists: true })).rejects.toThrow(
           DocumentAlreadyExistsError,
         )
+      } finally {
+        await docRef.delete()
+      }
+    })
+  })
+
+  describe('Queries on special-type fields', () => {
+    interface PlaceEntity extends Record<string, unknown> {
+      id: string
+      name: string
+      location: SerializedGeoPoint
+      owner: SerializedDocumentReference
+    }
+
+    it('should match documents by GeoPoint and DocumentReference values via where()', async () => {
+      const validator = (data: unknown) => data as PlaceEntity
+      const uniqueCollectionName = `test-places-${Date.now()}-${Math.random()}`
+      const collection = firestoreTyped.collection<PlaceEntity>(uniqueCollectionName, validator)
+
+      const location: SerializedGeoPoint = {
+        type: 'GeoPoint',
+        latitude: 35.6762,
+        longitude: 139.6503,
+      }
+      const owner: SerializedDocumentReference = {
+        type: 'DocumentReference',
+        path: `owners-${uniqueCollectionName}/owner-1`,
+        collectionId: `owners-${uniqueCollectionName}`,
+        documentId: 'owner-1',
+      }
+
+      const docRef = collection.doc('tokyo')
+      await docRef.set({ id: 'tokyo', name: 'Tokyo Office', location, owner })
+
+      try {
+        // Both queries return 0 results without query-value deserialization,
+        // because the stored native types never equal the serialized plain objects
+        const byLocation = await collection.where('location', '==', location).get()
+        expect(byLocation.size).toBe(1)
+        expect(byLocation.docs[0].data?.name).toBe('Tokyo Office')
+
+        const byOwner = await collection.where('owner', '==', owner).get()
+        expect(byOwner.size).toBe(1)
+        expect(byOwner.docs[0].data?.name).toBe('Tokyo Office')
       } finally {
         await docRef.delete()
       }

--- a/src/core/__tests__/unit/collection-group.unit.test.ts
+++ b/src/core/__tests__/unit/collection-group.unit.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, it, expect, beforeEach, type Mock, type MockedFunction } from 'vitest'
 import { CollectionGroup } from '../../collection-group'
 import { Query } from '../../query'
-import { serializeFirestoreTypes } from '../../../utils/firestore-converter'
+import { serializeFirestoreTypes, deserializeQueryValue } from '../../../utils/firestore-converter'
 import { validateData } from '../../../utils/validator'
 import type { FirestoreTypedOptionsProvider } from '../../../types/firestore-typed.types'
 import type { TestPostEntity } from '../../../__tests__/__helpers__/test-entities.helper'
@@ -19,6 +19,9 @@ const mockSerializeFirestoreTypes = serializeFirestoreTypes as MockedFunction<
   typeof serializeFirestoreTypes
 >
 const mockValidateData = validateData as MockedFunction<typeof validateData>
+const mockDeserializeQueryValue = deserializeQueryValue as MockedFunction<
+  typeof deserializeQueryValue
+>
 
 describe('CollectionGroup', () => {
   let mockFirebaseQuery: any
@@ -30,6 +33,7 @@ describe('CollectionGroup', () => {
     // Reset mocks
     vi.clearAllMocks()
     mockSerializeFirestoreTypes.mockImplementation((data) => data)
+    mockDeserializeQueryValue.mockImplementation((value: any) => value)
     mockValidateData.mockImplementation((data) => data as any)
 
     // Create mock Firebase Query (for collection group)

--- a/src/core/__tests__/unit/collection.unit.test.ts
+++ b/src/core/__tests__/unit/collection.unit.test.ts
@@ -5,6 +5,7 @@ import { Query } from '../../query'
 import {
   deserializeFirestoreTypes,
   serializeFirestoreTypes,
+  deserializeQueryValue,
 } from '../../../utils/firestore-converter'
 import { validateData } from '../../../utils/validator'
 import type { FirestoreTypedOptionsProvider } from '../../../types/firestore-typed.types'
@@ -30,6 +31,9 @@ const mockSerializeFirestoreTypes = serializeFirestoreTypes as MockedFunction<
   typeof serializeFirestoreTypes
 >
 const mockValidateData = validateData as MockedFunction<typeof validateData>
+const mockDeserializeQueryValue = deserializeQueryValue as MockedFunction<
+  typeof deserializeQueryValue
+>
 
 describe('CollectionReference', () => {
   let mockFirebaseCollection: any
@@ -44,6 +48,7 @@ describe('CollectionReference', () => {
     vi.clearAllMocks()
     mockDeserializeFirestoreTypes.mockImplementation((data: any) => data)
     mockSerializeFirestoreTypes.mockImplementation((data: any) => data)
+    mockDeserializeQueryValue.mockImplementation((value: any) => value)
     mockValidateData.mockImplementation((_data: any, _path: any, validator: any) =>
       validator(_data),
     )

--- a/src/core/__tests__/unit/query.unit.test.ts
+++ b/src/core/__tests__/unit/query.unit.test.ts
@@ -1,6 +1,6 @@
 import { vi, describe, it, expect, beforeEach, type Mock, type MockedFunction } from 'vitest'
 import { Query } from '../../query'
-import { serializeFirestoreTypes } from '../../../utils/firestore-converter'
+import { serializeFirestoreTypes, deserializeQueryValue } from '../../../utils/firestore-converter'
 import { validateData } from '../../../utils/validator'
 import type { FirestoreTypedOptionsProvider } from '../../../types/firestore-typed.types'
 import {
@@ -23,6 +23,9 @@ const mockSerializeFirestoreTypes = serializeFirestoreTypes as MockedFunction<
   typeof serializeFirestoreTypes
 >
 const mockValidateData = validateData as MockedFunction<typeof validateData>
+const mockDeserializeQueryValue = deserializeQueryValue as MockedFunction<
+  typeof deserializeQueryValue
+>
 
 describe('Query', () => {
   let mockFirebaseQuery: any
@@ -34,6 +37,7 @@ describe('Query', () => {
     // Reset mocks
     vi.clearAllMocks()
     mockSerializeFirestoreTypes.mockImplementation((data: any) => data)
+    mockDeserializeQueryValue.mockImplementation((value: any) => value)
     mockValidateData.mockImplementation((_data: any, _path: any, validator: any) =>
       validator(_data),
     )

--- a/src/core/collection-group.ts
+++ b/src/core/collection-group.ts
@@ -8,7 +8,7 @@ import type {
   DocumentSnapshot,
 } from '../types/firestore-typed.types'
 import { validateData } from '../utils/validator'
-import { serializeFirestoreTypes } from '../utils/firestore-converter'
+import { serializeFirestoreTypes, deserializeQueryValue } from '../utils/firestore-converter'
 
 /**
  * Typed wrapper for Firestore Collection Group queries
@@ -62,7 +62,7 @@ export class CollectionGroup<T extends SerializedDocumentData> {
    * Creates a new Query with where clause (Phase 2)
    */
   where<K extends keyof T & string>(field: K, op: WhereFilterOp, value: T[K]): Query<T> {
-    const query = this.query.where(field, op, value)
+    const query = this.query.where(field, op, deserializeQueryValue(value, this.query.firestore))
     return new Query<T>(query, this.firestoreTyped, this.validator)
   }
 

--- a/src/core/collection.ts
+++ b/src/core/collection.ts
@@ -7,7 +7,11 @@ import type {
 import { DocumentReference } from './document'
 import { Query } from './query'
 import { validateData } from '../utils/validator'
-import { serializeFirestoreTypes, deserializeFirestoreTypes } from '../utils/firestore-converter'
+import {
+  serializeFirestoreTypes,
+  deserializeFirestoreTypes,
+  deserializeQueryValue,
+} from '../utils/firestore-converter'
 import type {
   SerializedDocumentData,
   QuerySnapshot,
@@ -107,7 +111,7 @@ export class CollectionReference<T extends SerializedDocumentData> {
    * Creates a new Query with where clause (Phase 2)
    */
   where<K extends keyof T & string>(field: K, op: WhereFilterOp, value: T[K]): Query<T> {
-    const query = this.ref.where(field, op, value)
+    const query = this.ref.where(field, op, deserializeQueryValue(value, this.ref.firestore))
     return new Query<T>(query, this.firestoreTyped, this.validator)
   }
 

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -5,7 +5,7 @@ import type {
   DocumentData,
 } from 'firebase-admin/firestore'
 import { validateData } from '../utils/validator'
-import { serializeFirestoreTypes } from '../utils/firestore-converter'
+import { serializeFirestoreTypes, deserializeQueryValue } from '../utils/firestore-converter'
 import type {
   SerializedDocumentData,
   QuerySnapshot,
@@ -29,7 +29,7 @@ export class Query<T extends SerializedDocumentData> {
    * Add a where clause with type-safe field names
    */
   where<K extends keyof T & string>(field: K, op: WhereFilterOp, value: T[K]): Query<T> {
-    const newQuery = this.query.where(field, op, value)
+    const newQuery = this.query.where(field, op, deserializeQueryValue(value, this.query.firestore))
     return new Query<T>(newQuery, this.firestoreTyped, this.validator)
   }
 
@@ -53,7 +53,7 @@ export class Query<T extends SerializedDocumentData> {
    * Start pagination at a specific point
    */
   startAt(...fieldValues: unknown[]): Query<T> {
-    const newQuery = this.query.startAt(...fieldValues)
+    const newQuery = this.query.startAt(...this.deserializeCursorValues(fieldValues))
     return new Query<T>(newQuery, this.firestoreTyped, this.validator)
   }
 
@@ -61,7 +61,7 @@ export class Query<T extends SerializedDocumentData> {
    * Start pagination after a specific point
    */
   startAfter(...fieldValues: unknown[]): Query<T> {
-    const newQuery = this.query.startAfter(...fieldValues)
+    const newQuery = this.query.startAfter(...this.deserializeCursorValues(fieldValues))
     return new Query<T>(newQuery, this.firestoreTyped, this.validator)
   }
 
@@ -69,7 +69,7 @@ export class Query<T extends SerializedDocumentData> {
    * End pagination at a specific point
    */
   endAt(...fieldValues: unknown[]): Query<T> {
-    const newQuery = this.query.endAt(...fieldValues)
+    const newQuery = this.query.endAt(...this.deserializeCursorValues(fieldValues))
     return new Query<T>(newQuery, this.firestoreTyped, this.validator)
   }
 
@@ -77,8 +77,12 @@ export class Query<T extends SerializedDocumentData> {
    * End pagination before a specific point
    */
   endBefore(...fieldValues: unknown[]): Query<T> {
-    const newQuery = this.query.endBefore(...fieldValues)
+    const newQuery = this.query.endBefore(...this.deserializeCursorValues(fieldValues))
     return new Query<T>(newQuery, this.firestoreTyped, this.validator)
+  }
+
+  private deserializeCursorValues(fieldValues: unknown[]): unknown[] {
+    return fieldValues.map((value) => deserializeQueryValue(value, this.query.firestore))
   }
 
   /**

--- a/src/utils/firestore-converter.ts
+++ b/src/utils/firestore-converter.ts
@@ -97,6 +97,18 @@ export function deserializeFirestoreTypes(
 }
 
 /**
+ * Converts a single query operand (where() value or cursor value) to its
+ * Firestore representation (Date → Timestamp, SerializedGeoPoint → GeoPoint,
+ * SerializedDocumentReference → DocumentReference).
+ *
+ * Stored documents go through deserializeFirestoreTypes on write, so query
+ * operands must receive the same conversion or comparisons never match.
+ */
+export function deserializeQueryValue(value: unknown, firestore: Firestore): unknown {
+  return deserializeFirestoreTypesInternal(value, firestore)
+}
+
+/**
  * Internal recursive deserialization function
  */
 function deserializeFirestoreTypesInternal(data: unknown, firestore: Firestore): unknown {


### PR DESCRIPTION
## Summary

Closes #93 (High severity, from the 2026-07-10 external code review).

Writes convert `SerializedGeoPoint` / `SerializedDocumentReference` into native Firestore types, but query operands were passed through unchanged. A stored native `GeoPoint` was compared against the plain map `{ type: 'GeoPoint', ... }`, so wrapper-issued queries on those fields **silently returned 0 results** (confirmed empirically by the reviewer, and now by an emulator regression test).

## Changes

- **firestore-converter.ts**: new `deserializeQueryValue(value, firestore)` — value-level counterpart of `deserializeFirestoreTypes` (Date → Timestamp, SerializedGeoPoint → GeoPoint, SerializedDocumentReference → DocumentReference, recursing into arrays/objects)
- Applied at every query-operand entry point:
  - `Query.where()` and the four cursor methods (`startAt` / `startAfter` / `endAt` / `endBefore`)
  - `CollectionReference.where()`
  - `CollectionGroup.where()`
- **Unit tests**: passthrough mocks for the new converter function in the three affected suites
- **Emulator regression test**: stores a document with `GeoPoint` + `DocumentReference` fields and matches it via wrapper `where()` — returns 0 results on the old code

## Notes

- `Date` operands were already handled by the SDK's own conversion; behavior for them is unchanged
- Primitive operands (string/number/boolean) pass through untouched

## Verification

- ✅ `npm test` — 241 tests pass
- ✅ `npm run test:emulator` — 7 tests pass (new special-type query test included)
- ✅ `npm run typecheck` / `lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)