### PR TITLE
fix: run merge() read-modify-write inside a transaction

### DIFF
--- a/src/core/__tests__/emulator/firestore-typed.emulator.test.ts
+++ b/src/core/__tests__/emulator/firestore-typed.emulator.test.ts
@@ -137,6 +137,29 @@ describe('FirestoreTyped Core Class (Emulator)', () => {
     })
   })
 
+  describe('merge() concurrency', () => {
+    it('should not lose a concurrent update to a different field', async () => {
+      const validator = createSimpleTestEntityValidator()
+      const uniqueCollectionName = `test-merge-${Date.now()}-${Math.random()}`
+      const collection = firestoreTyped.collection(uniqueCollectionName, validator)
+      const docRef = collection.doc('shared-doc')
+
+      await docRef.set(createSimpleTestEntity({ id: '123', name: 'Original', age: 1 }))
+
+      try {
+        // Without a transaction, one merge's full-document overwrite can
+        // silently drop the other merge's field update
+        await Promise.all([docRef.merge({ name: 'Updated Name' }), docRef.merge({ age: 99 })])
+
+        const snapshot = await docRef.get()
+        expect(snapshot.data?.name).toBe('Updated Name')
+        expect(snapshot.data?.age).toBe(99)
+      } finally {
+        await docRef.delete()
+      }
+    })
+  })
+
   describe('Queries on special-type fields', () => {
     interface PlaceEntity extends Record<string, unknown> {
       id: string

--- a/src/core/__tests__/unit/document.unit.test.ts
+++ b/src/core/__tests__/unit/document.unit.test.ts
@@ -32,6 +32,8 @@ const mockValidateData = validateData as MockedFunction<typeof validateData>
 
 describe('DocumentReference', () => {
   let mockFirebaseDoc: any
+  let mockTransaction: any
+  let mockFirestore: any
   let mockFirestoreTyped: FirestoreTypedOptionsProvider
   let mockValidator: Mock
   let docRef: DocumentReference<TestEntity>
@@ -47,11 +49,21 @@ describe('DocumentReference', () => {
       validator(_data),
     )
 
+    // Transaction mock delegates to the document mock so per-test
+    // get/set expectations keep working for transactional operations
+    mockTransaction = {
+      get: vi.fn(() => mockFirebaseDoc.get()),
+      set: vi.fn((_ref: unknown, data: unknown) => mockFirebaseDoc.set(data)),
+    }
+    mockFirestore = {
+      runTransaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(mockTransaction)),
+    }
+
     // Create mock Firebase DocumentReference
     mockFirebaseDoc = {
       id: 'test-id',
       path: 'users/test-id',
-      firestore: {},
+      firestore: mockFirestore,
       get: vi.fn(),
       set: vi.fn(),
       create: vi.fn(),
@@ -192,7 +204,7 @@ describe('DocumentReference', () => {
 
       await docRef.set(testData)
 
-      expect(mockDeserializeFirestoreTypes).toHaveBeenCalledWith(testData, {})
+      expect(mockDeserializeFirestoreTypes).toHaveBeenCalledWith(testData, mockFirestore)
       expect(mockFirebaseDoc.set).toHaveBeenCalledWith(convertedData)
     })
 
@@ -308,6 +320,24 @@ describe('DocumentReference', () => {
       expect(mockFirebaseDoc.set).not.toHaveBeenCalled()
     })
 
+    it('should run the read-modify-write inside a transaction', async () => {
+      mockFirebaseDoc.get.mockResolvedValue({
+        exists: true,
+        id: 'test-id',
+        ref: mockFirebaseDoc,
+        data: () => testData,
+      })
+
+      await docRef.merge(partialData)
+
+      expect(mockFirestore.runTransaction).toHaveBeenCalledTimes(1)
+      expect(mockTransaction.get).toHaveBeenCalledWith(mockFirebaseDoc)
+      expect(mockTransaction.set).toHaveBeenCalledWith(mockFirebaseDoc, {
+        ...testData,
+        ...partialData,
+      })
+    })
+
     it('should validate merged data when validateOnWrite is true', async () => {
       mockFirebaseDoc.get.mockResolvedValue({
         exists: true,
@@ -341,7 +371,7 @@ describe('DocumentReference', () => {
 
       expect(mockDeserializeFirestoreTypes).toHaveBeenCalledWith(
         { ...testData, ...partialData },
-        {},
+        mockFirestore,
       )
       expect(mockFirebaseDoc.set).toHaveBeenCalledWith(convertedData)
     })
@@ -416,7 +446,7 @@ describe('DocumentReference', () => {
       // The merged data should be just the partial data since existing was null
       expect(mockDeserializeFirestoreTypes).toHaveBeenCalledWith(
         partialData, // Since existingData was null, mergedData is just partialData
-        {},
+        mockFirestore,
       )
     })
   })

--- a/src/core/document.ts
+++ b/src/core/document.ts
@@ -115,32 +115,38 @@ export class DocumentReference<T extends SerializedDocumentData> {
 
   /**
    * Merges partial data with existing document data and validates the complete schema
+   *
+   * Runs inside a transaction so the write is conditioned on the read snapshot:
+   * a concurrent update between read and write aborts and retries the merge
+   * instead of being silently overwritten.
    */
   async merge(data: Partial<T>, options?: WriteOptions): Promise<void> {
-    const snapshot = await this.ref.get()
-    if (!snapshot.exists) {
-      throw new DocumentNotFoundError(this.path)
-    }
-
     const globalOptions = this.firestoreTyped.getOptions()
     const validateOnWrite = options?.validateOnWrite ?? globalOptions.validateOnWrite
 
-    // Merge with existing data
-    const existingData = snapshot.data() || {}
-    // Convert Firestore types in existing data before merging
-    const convertedExistingData = serializeFirestoreTypes(existingData)
-    const mergedData = { ...convertedExistingData, ...data }
+    await this.ref.firestore.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(this.ref)
+      if (!snapshot.exists) {
+        throw new DocumentNotFoundError(this.path)
+      }
 
-    // Validate the complete merged data
-    const validatedData = validateOnWrite
-      ? validateData<T>(mergedData, this.path, this.validator)
-      : (mergedData as T)
+      // Merge with existing data
+      const existingData = snapshot.data() || {}
+      // Convert Firestore types in existing data before merging
+      const convertedExistingData = serializeFirestoreTypes(existingData)
+      const mergedData = { ...convertedExistingData, ...data }
 
-    // Deserialize the complete validated data before writing to Firestore
-    const deserializedData = deserializeFirestoreTypes(validatedData, this.ref.firestore)
+      // Validate the complete merged data (a validation failure aborts the transaction)
+      const validatedData = validateOnWrite
+        ? validateData<T>(mergedData, this.path, this.validator)
+        : (mergedData as T)
 
-    // Use set to ensure the complete schema is written
-    await this.ref.set(deserializedData)
+      // Deserialize the complete validated data before writing to Firestore
+      const deserializedData = deserializeFirestoreTypes(validatedData, this.ref.firestore)
+
+      // Use set to ensure the complete schema is written
+      transaction.set(this.ref, deserializedData)
+    })
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #94 (High severity, from the 2026-07-10 external code review — the last of the three high-severity findings).

`merge()` read the document, merged locally, and overwrote the full document with `set()`. Any update committed between the read and the write was silently lost.

## Changes

- **src/core/document.ts**: the read → merge → validate → write sequence now runs inside `firestore.runTransaction()`. The write is conditioned on the read snapshot; contended merges are retried by Firestore against fresh data instead of clobbering each other.
- **Error semantics preserved**:
  - `DocumentNotFoundError` for missing documents (thrown inside the transaction, propagates unchanged)
  - full-schema validation still runs against the merged result; a validation failure aborts the transaction and propagates as `FirestoreTypedValidationError` — nothing is written
- **Unit tests**: transaction mock delegates `get`/`set` to the document mock so existing expectations keep working; new test asserts the read-modify-write actually goes through `runTransaction` / `transaction.get` / `transaction.set`
- **Emulator regression test**: two concurrent `merge()` calls updating different fields — both updates must survive (`name` and `age` both present afterwards). Racy-lossy on the old implementation.

## Verification

- ✅ `npm test` — 242 tests pass
- ✅ `npm run test:emulator` — 8 tests pass
- ✅ `npm run typecheck` / `lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)