### PR TITLE
fix: preserve Buffer/Uint8Array values through type conversion

### DIFF
--- a/src/core/__tests__/emulator/firestore-typed.emulator.test.ts
+++ b/src/core/__tests__/emulator/firestore-typed.emulator.test.ts
@@ -204,6 +204,34 @@ describe('FirestoreTyped Core Class (Emulator)', () => {
     })
   })
 
+  describe('Binary field round-trip', () => {
+    it('should preserve Buffer bytes through write and read', async () => {
+      interface BlobEntity extends Record<string, unknown> {
+        id: string
+        payload: Uint8Array
+      }
+      const validator = (data: unknown) => data as BlobEntity
+      const uniqueCollectionName = `test-bytes-${Date.now()}-${Math.random()}`
+      const collection = firestoreTyped.collection<BlobEntity>(uniqueCollectionName, validator)
+      const docRef = collection.doc('blob-doc')
+
+      const payload = Buffer.from([0xde, 0xad, 0xbe, 0xef])
+      await docRef.set({ id: 'blob', payload })
+
+      try {
+        const snapshot = await docRef.get()
+        const stored = snapshot.data?.payload
+
+        // Without binary passthrough this comes back as an index-keyed
+        // plain object like { "0": 222, "1": 173, ... }
+        expect(stored).toBeInstanceOf(Uint8Array)
+        expect(Buffer.from(stored as Uint8Array).equals(payload)).toBe(true)
+      } finally {
+        await docRef.delete()
+      }
+    })
+  })
+
   describe('Validation behavior', () => {
     it('should validate on write when enabled', async () => {
       const instance = new FirestoreTyped(emulator.firestore, { validateOnWrite: true })

--- a/src/utils/__tests__/unit/firestore-converter.unit.test.ts
+++ b/src/utils/__tests__/unit/firestore-converter.unit.test.ts
@@ -201,6 +201,28 @@ describe('Firestore Converter', () => {
         expect(result).toEqual({})
       })
     })
+
+    describe('Binary Value Preservation', () => {
+      it('should pass Buffer values through unchanged', () => {
+        const buffer = Buffer.from([0xde, 0xad, 0xbe, 0xef])
+
+        const result = serializeFirestoreTypes({ payload: buffer }) as any
+
+        expect(result.payload).toBe(buffer)
+      })
+
+      it('should pass Uint8Array values through unchanged, including nested ones', () => {
+        const bytes = new Uint8Array([1, 2, 3])
+
+        const result = serializeFirestoreTypes({
+          nested: { data: bytes },
+          list: [bytes],
+        }) as any
+
+        expect(result.nested.data).toBe(bytes)
+        expect(result.list[0]).toBe(bytes)
+      })
+    })
   })
 
   describe('deserializeFirestoreTypes', () => {
@@ -498,6 +520,19 @@ describe('Firestore Converter', () => {
 
       const result = deserializeFirestoreTypes({ author: validDocRef }, mockFirestore) as any
       expect(result.author).toBe(mockDocRef)
+    })
+
+    it('should pass binary values through unchanged', () => {
+      const buffer = Buffer.from([0xca, 0xfe])
+      const bytes = new Uint8Array([4, 5, 6])
+
+      const result = deserializeFirestoreTypes(
+        { payload: buffer, nested: { data: bytes } },
+        mockFirestore,
+      ) as any
+
+      expect(result.payload).toBe(buffer)
+      expect(result.nested.data).toBe(bytes)
     })
 
     it('should handle invalid type objects that fail type guards', () => {

--- a/src/utils/firestore-converter.ts
+++ b/src/utils/firestore-converter.ts
@@ -69,6 +69,12 @@ function serializeFirestoreTypesInternal(data: unknown): unknown {
     }
   }
 
+  if (isBinaryValue(data)) {
+    // Firestore bytes fields (Buffer/Uint8Array) must pass through unchanged;
+    // copying them via Object.entries would corrupt them into index-keyed maps
+    return data
+  }
+
   if (Array.isArray(data)) {
     // Recursively convert arrays
     return data.map((item: unknown) => serializeFirestoreTypesInternal(item))
@@ -80,6 +86,14 @@ function serializeFirestoreTypesInternal(data: unknown): unknown {
     result[key] = serializeFirestoreTypesInternal(value)
   }
   return result
+}
+
+/**
+ * Binary values supported by Firestore as bytes fields
+ * (Buffer is a Uint8Array subclass, so this covers both)
+ */
+function isBinaryValue(data: unknown): data is Uint8Array {
+  return data instanceof Uint8Array
 }
 
 /**
@@ -129,6 +143,11 @@ function deserializeFirestoreTypesInternal(data: unknown, firestore: Firestore):
   // SerializedDocumentReference -> DocumentReference
   if (isSerializedDocumentReference(data)) {
     return firestore.doc(data.path)
+  }
+
+  if (isBinaryValue(data)) {
+    // Firestore bytes fields (Buffer/Uint8Array) must pass through unchanged
+    return data
   }
 
   if (Array.isArray(data)) {


### PR DESCRIPTION
## Summary

Closes #97 (Medium severity, from the 2026-07-10 external code review).

Both converter directions copied unrecognized objects via `Object.entries()`, so Firestore-supported bytes fields (`Buffer` / `Uint8Array`) were destructively flattened into index-keyed maps (`{ "0": 222, "1": 173, ... }`) — on the write path *and* the read path, making the corruption a full round-trip data loss.

## Changes

- **firestore-converter.ts**: binary values now pass through unchanged in both `serializeFirestoreTypesInternal` and `deserializeFirestoreTypesInternal`. A single `instanceof Uint8Array` check covers both types (`Buffer` is a `Uint8Array` subclass).
- **Unit tests**: passthrough assertions for Buffer and Uint8Array, top-level and nested (objects/arrays), in both directions
- **Emulator regression test**: writes a document with a `Buffer` payload and asserts the read-back value is a byte-identical `Uint8Array` (comes back as an index-keyed plain object on the old code)

## Out of scope

Whether *other* unknown class instances should throw instead of being silently flattened is a separate behavior decision — left with the notes in #97.

## Verification

- ✅ `npm test` — 245 tests pass
- ✅ `npm run test:emulator` — 9 tests pass
- ✅ `npm run typecheck` / `lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)