### PR TITLE
types: model where() operator operand types; brand SerializedDocumentReference

### DIFF
--- a/src/core/__tests__/unit/collection-group.unit.test.ts
+++ b/src/core/__tests__/unit/collection-group.unit.test.ts
@@ -81,7 +81,7 @@ describe('CollectionGroup', () => {
       it('should support chaining with multiple where clauses', () => {
         const query = collectionGroup
           .where('authorId', '==', 'user-1')
-          .where('tags', 'array-contains', 'test' as any)
+          .where('tags', 'array-contains', 'test')
 
         expect(query).toBeInstanceOf(Query)
       })

--- a/src/core/__tests__/unit/query.unit.test.ts
+++ b/src/core/__tests__/unit/query.unit.test.ts
@@ -83,9 +83,19 @@ describe('Query', () => {
         query.where('age', '>', 18)
         expect(mockFirebaseQuery.where).toHaveBeenCalledWith('age', '>', 18)
 
-        // For 'in' operator, cast to any to handle union type limitations
-        query.where('status', 'in', ['active', 'inactive'] as any)
+        // 'in' takes an array of field values (typed via WhereFilterValue)
+        query.where('status', 'in', ['active', 'inactive'])
         expect(mockFirebaseQuery.where).toHaveBeenCalledWith('status', 'in', ['active', 'inactive'])
+      })
+
+      it('should reject operand types that do not match the operator', () => {
+        // @ts-expect-error 'in' requires an array of field values, not a single value
+        query.where('status', 'in', 'active')
+
+        // @ts-expect-error equality against an array is not valid for a scalar field
+        query.where('age', '==', [18])
+
+        expect(mockFirebaseQuery.where).toHaveBeenCalledTimes(2)
       })
 
       it('should be chainable', () => {

--- a/src/core/__tests__/unit/query.unit.test.ts
+++ b/src/core/__tests__/unit/query.unit.test.ts
@@ -335,7 +335,7 @@ describe('Query', () => {
         taggedValidator,
       )
 
-      taggedQuery.where('tags', 'array-contains', 'important' as any)
+      taggedQuery.where('tags', 'array-contains', 'important')
 
       expect(mockFirebaseQuery.where).toHaveBeenCalledWith('tags', 'array-contains', 'important')
     })

--- a/src/core/collection-group.ts
+++ b/src/core/collection-group.ts
@@ -6,6 +6,7 @@ import type {
   ReadOptions,
   QuerySnapshot,
   DocumentSnapshot,
+  WhereFilterValue,
 } from '../types/firestore-typed.types'
 import { validateData } from '../utils/validator'
 import { serializeFirestoreTypes, deserializeQueryValue } from '../utils/firestore-converter'
@@ -61,7 +62,11 @@ export class CollectionGroup<T extends SerializedDocumentData> {
   /**
    * Creates a new Query with where clause (Phase 2)
    */
-  where<K extends keyof T & string>(field: K, op: WhereFilterOp, value: T[K]): Query<T> {
+  where<K extends keyof T & string, Op extends WhereFilterOp>(
+    field: K,
+    op: Op,
+    value: WhereFilterValue<T, K, Op>,
+  ): Query<T> {
     const query = this.query.where(field, op, deserializeQueryValue(value, this.query.firestore))
     return new Query<T>(query, this.firestoreTyped, this.validator)
   }

--- a/src/core/collection.ts
+++ b/src/core/collection.ts
@@ -19,6 +19,7 @@ import type {
   ReadOptions,
   WriteOptions,
   FirestoreTypedOptionsProvider,
+  WhereFilterValue,
 } from '../types/firestore-typed.types'
 
 /**
@@ -110,7 +111,11 @@ export class CollectionReference<T extends SerializedDocumentData> {
   /**
    * Creates a new Query with where clause (Phase 2)
    */
-  where<K extends keyof T & string>(field: K, op: WhereFilterOp, value: T[K]): Query<T> {
+  where<K extends keyof T & string, Op extends WhereFilterOp>(
+    field: K,
+    op: Op,
+    value: WhereFilterValue<T, K, Op>,
+  ): Query<T> {
     const query = this.ref.where(field, op, deserializeQueryValue(value, this.ref.firestore))
     return new Query<T>(query, this.firestoreTyped, this.validator)
   }

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -12,6 +12,7 @@ import type {
   DocumentSnapshot,
   ReadOptions,
   FirestoreTypedOptionsProvider,
+  WhereFilterValue,
 } from '../types/firestore-typed.types'
 
 /**
@@ -28,7 +29,11 @@ export class Query<T extends SerializedDocumentData> {
   /**
    * Add a where clause with type-safe field names
    */
-  where<K extends keyof T & string>(field: K, op: WhereFilterOp, value: T[K]): Query<T> {
+  where<K extends keyof T & string, Op extends WhereFilterOp>(
+    field: K,
+    op: Op,
+    value: WhereFilterValue<T, K, Op>,
+  ): Query<T> {
     const newQuery = this.query.where(field, op, deserializeQueryValue(value, this.query.firestore))
     return new Query<T>(newQuery, this.firestoreTyped, this.validator)
   }

--- a/src/types/firestore-typed.types.ts
+++ b/src/types/firestore-typed.types.ts
@@ -54,6 +54,29 @@ export interface WriteOptions {
 export type SerializedDocumentData = object
 
 /**
+ * Maps a Firestore where() operator to the operand type it expects for field K:
+ * - `in` / `not-in` compare against an array of field values
+ * - `array-contains` compares against a single element of an array field
+ * - `array-contains-any` compares against an array of elements of an array field
+ * - all other operators compare against the field value itself
+ */
+export type WhereFilterValue<
+  T,
+  K extends keyof T,
+  Op extends import('firebase-admin/firestore').WhereFilterOp,
+> = Op extends 'in' | 'not-in'
+  ? readonly T[K][]
+  : Op extends 'array-contains'
+    ? T[K] extends readonly (infer E)[]
+      ? E
+      : never
+    : Op extends 'array-contains-any'
+      ? T[K] extends readonly (infer E)[]
+        ? readonly E[]
+        : never
+      : T[K]
+
+/**
  * Metadata about a document
  */
 export interface DocumentMetadata {

--- a/src/utils/__tests__/unit/firestore-converter.unit.test.ts
+++ b/src/utils/__tests__/unit/firestore-converter.unit.test.ts
@@ -515,4 +515,27 @@ describe('Firestore Converter', () => {
       })
     })
   })
+
+  describe('SerializedDocumentReference type branding', () => {
+    it('should not allow references to different document types to be assigned to each other', () => {
+      interface UserDoc {
+        name: string
+      }
+      interface OrderDoc {
+        total: number
+      }
+
+      const userRef: SerializedDocumentReference<'users', UserDoc> = {
+        type: 'DocumentReference',
+        path: 'users/user-1',
+        collectionId: 'users',
+        documentId: 'user-1',
+      }
+
+      // @ts-expect-error references to different document types must not be assignable
+      const orderRef: SerializedDocumentReference<'users', OrderDoc> = userRef
+
+      expect(orderRef).toBe(userRef)
+    })
+  })
 })

--- a/src/utils/firestore-converter.ts
+++ b/src/utils/firestore-converter.ts
@@ -14,17 +14,22 @@ export interface SerializedGeoPoint {
 /**
  * Serialized DocumentReference type
  * @template TCollection - Collection name type
- * @template TDocument - Document type (for type-level information)
+ * @template TDocument - Referenced document type
  */
 export interface SerializedDocumentReference<
   TCollection extends string = string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   TDocument = unknown,
 > {
   type: 'DocumentReference'
   path: string
   collectionId: TCollection
   documentId: string
+  /**
+   * Phantom brand carrying the referenced document type at the type level,
+   * so references to different document types are not mutually assignable.
+   * Never present at runtime.
+   */
+  readonly __documentType?: TDocument
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #96 and #98 (both Medium severity, type-level findings from the 2026-07-10 external code review). No runtime behavior changes.

## Changes

### where() operator typing (#96)

New `WhereFilterValue<T, K, Op>` conditional type in `firestore-typed.types.ts`:

| Operator | Operand type |
|---|---|
| `in` / `not-in` | `readonly T[K][]` |
| `array-contains` | element type of `T[K]` |
| `array-contains-any` | `readonly` array of element type |
| everything else | `T[K]` |

Applied to `where()` on `Query`, `CollectionReference`, and `CollectionGroup`. The `as any` previously required for `in` queries in our own tests is now gone, and `@ts-expect-error` tests pin the rejections (single value for `in`, array for scalar `==`).

### SerializedDocumentReference branding (#98)

`TDocument` was a phantom parameter unused in any member (flagged by its own `eslint-disable no-unused-vars`), so references to different document types in the same collection were mutually assignable. Added an optional phantom brand:

```typescript
/** Never present at runtime */
readonly __documentType?: TDocument
```

A `@ts-expect-error` test asserts `SerializedDocumentReference<'users', UserDoc>` is no longer assignable to `SerializedDocumentReference<'users', OrderDoc>`. Object literals without the member remain assignable (it's optional), so existing construction sites and validators are unaffected.

## Compatibility note

Strictly-variant consumers could see new type errors where they previously mixed document types across references — that is the point of the fix. Runtime output is identical.

## Verification

- ✅ `npm test` — 244 tests pass (2 new type-pinning tests)
- ✅ `npm run typecheck` / `lint` / `build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)