### PR TITLE
docs: align README API reference with the implemented API

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1143,9 +1143,11 @@ const data = await userCollection.doc('user-id').get({ validateOnRead: true })
 
 ```typescript
 // ✅ 良い例: 横断コレクション検索にコレクショングループクエリを使用
-const allProducts = await db.queryCollectionGroup('products', (query) =>
-  query.where('category', '==', 'electronics').orderBy('name')
-)
+const productsGroup = db.collectionGroup<ProductEntity>('products', productValidator)
+const electronicsProducts = await productsGroup
+  .where('category', '==', 'electronics')
+  .orderBy('name')
+  .get()
 
 // ✅ 良い例: 単一コレクション用の通常のコレクションクエリ
 const categoryProducts = await db.collection<ProductEntity>('categories/electronics/products', productValidator).get()
@@ -1191,6 +1193,7 @@ await batch.commit()
  * ```
  */
 function getFirestoreTyped(
+  firestore?: Firestore,
   options?: FirestoreTypedOptions
 ): FirestoreTyped
 ```
@@ -1261,48 +1264,6 @@ class FirestoreTyped {
    * ```
    */
   get native(): Firestore
-
-  /**
-   * 複数コレクション横断でコレクショングループクエリを実行
-   * @param collectionId - 横断検索するコレクションID
-   * @param queryFn - オプションのクエリビルダー関数
-   * @returns すべての一致するコレクションからのクエリ結果
-   * @throws バリデーション失敗時FirestoreTypedValidationError
-   * @example
-   * ```typescript
-   * // すべてのカテゴリで全商品を検索
-   * const allProducts = await db.queryCollectionGroup('products')
-   * 
-   * // クエリ制約付き
-   * const electronicsProducts = await db.queryCollectionGroup('products', (query) =>
-   *   query.where('category', '==', 'electronics').orderBy('name')
-   * )
-   * ```
-   */
-  queryCollectionGroup<T>(
-    collectionId: string, 
-    queryFn?: (query: Query) => Query
-  ): Promise<QuerySnapshot<T>>
-
-  /**
-   * コレクショングループ横断で特定ドキュメントを検索
-   * @param collectionId - 検索するコレクションID
-   * @param documentId - 検索するドキュメントID
-   * @returns 見つかった場合はドキュメントデータ、それ以外はnull
-   * @throws バリデーション失敗時FirestoreTypedValidationError
-   * @example
-   * ```typescript
-   * // すべてのカテゴリ/商品でユーザーを検索
-   * const user = await db.findDocumentInCollectionGroup('users', 'user123')
-   * if (user) {
-   *   console.log(`Found user: ${user.name}`)
-   * }
-   * ```
-   */
-  findDocumentInCollectionGroup<T>(
-    collectionId: string, 
-    documentId: string
-  ): Promise<T | null>
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1167,12 +1167,16 @@ const data = await userCollection.doc('user-id').get({ validateOnRead: true })
 
 ```typescript
 // ✅ Good: Use collection group queries for cross-collection searches
-const allProducts = await db.queryCollectionGroup('products', (query) =>
-  query.where('category', '==', 'electronics').orderBy('name')
-)
+const productsGroup = db.collectionGroup<ProductEntity>('products', productValidator)
+const electronicsProducts = await productsGroup
+  .where('category', '==', 'electronics')
+  .orderBy('name')
+  .get()
 
 // ✅ Good: Regular collection queries for single collection
-const userProducts = await db.collection('users/user-001/products').get()
+const userProducts = await db
+  .collection<ProductEntity>('users/user-001/products', productValidator)
+  .get()
 ```
 
 ### 6. Performance Considerations
@@ -1215,6 +1219,7 @@ await batch.commit()
  * ```
  */
 function getFirestoreTyped(
+  firestore?: Firestore,
   options?: FirestoreTypedOptions
 ): FirestoreTyped
 ```
@@ -1285,48 +1290,6 @@ class FirestoreTyped {
    * ```
    */
   get native(): Firestore
-
-  /**
-   * Performs collection group query across multiple collections
-   * @param collectionId - Collection ID to search across
-   * @param queryFn - Optional query builder function
-   * @returns Query results from all matching collections
-   * @throws FirestoreTypedValidationError if validation fails
-   * @example
-   * ```typescript
-   * // Find all products across all users
-   * const allProducts = await db.queryCollectionGroup('products')
-   * 
-   * // With query constraints
-   * const electronicsProducts = await db.queryCollectionGroup('products', (query) =>
-   *   query.where('category', '==', 'electronics').orderBy('name')
-   * )
-   * ```
-   */
-  queryCollectionGroup<T>(
-    collectionId: string, 
-    queryFn?: (query: Query) => Query
-  ): Promise<QuerySnapshot<T>>
-
-  /**
-   * Finds specific document across collection groups
-   * @param collectionId - Collection ID to search in
-   * @param documentId - Document ID to find
-   * @returns Document data if found, null otherwise
-   * @throws FirestoreTypedValidationError if validation fails
-   * @example
-   * ```typescript
-   * // Find user across all users/products
-   * const user = await db.findDocumentInCollectionGroup('publicUsers', 'user123')
-   * if (user) {
-   *   console.log(`Found user: ${user.name}`)
-   * }
-   * ```
-   */
-  findDocumentInCollectionGroup<T>(
-    collectionId: string, 
-    documentId: string
-  ): Promise<T | null>
 }
 ```
 


### PR DESCRIPTION
## Summary

Closes #100 (Low severity, from the 2026-07-10 external code review).

## Changes (both README.md and README.ja.md)

- **`getFirestoreTyped` signature**: added the missing first parameter — the reference declared `(options?)` while the implementation (and the usage example directly above) is `(firestore?: Firestore, options?: FirestoreTypedOptions)`
- **Removed phantom methods**: `queryCollectionGroup()` and `findDocumentInCollectionGroup()` were documented on `FirestoreTyped` but exist nowhere in `src/`. The real API — `collectionGroup(collectionId, validator)` returning a `CollectionGroup` with `where()/orderBy()/limit()/get()` — was already correctly documented in the same section
- **Best-practices example**: rewritten from the non-existent `db.queryCollectionGroup('products', queryFn)` call to the real chain:
  ```typescript
  const productsGroup = db.collectionGroup<ProductEntity>('products', productValidator)
  const electronicsProducts = await productsGroup
    .where('category', '==', 'electronics')
    .orderBy('name')
    .get()
  ```

Documentation-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)