### PR TITLE
docs: describe validation defaults accurately in README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -5,7 +5,7 @@
 [![codecov](https://codecov.io/gh/InfoLoungeLLC/firestore-typed/branch/main/graph/badge.svg)](https://codecov.io/gh/InfoLoungeLLC/firestore-typed)
 [![license](https://img.shields.io/npm/l/@info-lounge/firestore-typed.svg)](https://github.com/InfoLoungeLLC/firestore-typed/blob/main/LICENSE)
 
-**必須ランタイムバリデーション**付きFirebase Firestoreの型安全な低レベルラッパーです。このパッケージは、**読み書き操作時にtypiaValidatorを用いてすべてのデータがバリデーションされることを保証**し、包括的な型安全性、データ整合性、改善された開発者体験をFirestore操作に提供します。
+**バリデータファースト設計**のFirebase Firestore向け型安全な低レベルラッパーです。すべてのコレクションにランタイムバリデータ(typiaまたはzod)が必須で、**書き込みはデフォルトで検証され、`validateOnRead`を有効にすれば読み取りも検証されます**。包括的な型安全性、データ整合性、改善された開発者体験をFirestore操作に提供します。
 
 > **[English README here / 英語版READMEはこちら →](README.md)**
 
@@ -43,7 +43,7 @@ await users.doc('123').set({
 
 ## 主要機能
 
-- **🛡️ 必須ランタイムバリデーション**: 読み書き操作時にtypiaValidatorで自動的にすべてのデータをバリデーション
+- **🛡️ バリデータファースト設計**: すべてのコレクションにランタイムバリデータが必須 — 書き込みはデフォルトで検証、読み取りは`validateOnRead: true`でオプトイン
 - **🔒 型安全性**: 完全なTypeScriptコンパイル時・ランタイム型チェック
 - **⚡ パフォーマンス最適化**: 最大のデータ整合性で最小のオーバーヘッド
 - **🎯 Firebaseネイティブ**: FirestoreのネイティブAPIパターンへの直接マッピング
@@ -143,7 +143,7 @@ npx ts-node your-file.ts
 
 ### なぜFirestoreTypedなのか？
 
-**FirestoreTypedの核心原則：すべてのデータがバリデーションされる。**生のFirestore操作とは異なり、FirestoreTypedはすべての操作にvalidatorを必須とすることでデータ整合性を保証します。
+**FirestoreTypedの核心原則：バリデータのないコレクションは作れない。**生のFirestore操作とは異なり、書き込みはデフォルトで検証され、`validateOnRead`を有効にすれば読み取りも検証されます(パフォーマンスのためデフォルトはオフ)。
 
 ```typescript
 // ❌ 生のFirestore - バリデーションなし、ランタイムエラーの可能性
@@ -199,7 +199,8 @@ await usersCollection.doc('user-001').set({
 
 // ✅ このデータは読み取り後にバリデーションされる（validateOnRead: trueの場合）
 const user = await usersCollection.doc('user-001').get()
-// user.dataはUserEntityと一致するかバリデーションエラーをスローすることが保証される
+// validateOnRead: trueの場合、user.dataはUserEntityと一致することが保証される
+// (一致しなければバリデーションエラー)。無効の場合はデータがそのまま返る
 ```
 
 ### カスタムFirestoreインスタンスの使用

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov](https://codecov.io/gh/InfoLoungeLLC/firestore-typed/branch/main/graph/badge.svg)](https://codecov.io/gh/InfoLoungeLLC/firestore-typed)
 [![license](https://img.shields.io/npm/l/@info-lounge/firestore-typed.svg)](https://github.com/InfoLoungeLLC/firestore-typed/blob/main/LICENSE)
 
-A type-safe, low-level wrapper for Firebase Firestore with **mandatory runtime validation**. This package ensures that **all data is validated using typia validators during both read and write operations**, providing comprehensive type safety, data integrity, and improved developer experience for Firestore operations.
+A type-safe, low-level wrapper for Firebase Firestore with a **validator-first design**. Every collection requires a runtime validator (typia or zod): **writes are validated by default, and reads are validated too when `validateOnRead` is enabled**, providing comprehensive type safety, data integrity, and improved developer experience for Firestore operations.
 
 > **[日本語のREADMEはこちら / Japanese README here →](README.ja.md)**
 
@@ -43,7 +43,7 @@ await users.doc('123').set({
 
 ## Key Features
 
-- **🛡️ Mandatory Runtime Validation**: All data is automatically validated using typia validators on read/write operations
+- **🛡️ Validator-First Architecture**: every collection requires a runtime validator — writes are validated by default, reads opt in via `validateOnRead: true`
 - **🔒 Type Safety**: Full TypeScript compile-time and runtime type checking
 - **⚡ Performance Optimized**: Minimal overhead with maximum data integrity
 - **🎯 Firebase Native**: Direct mapping to Firestore's native API patterns
@@ -144,7 +144,7 @@ npx ts-node your-file.ts
 
 ### Why FirestoreTyped?
 
-**FirestoreTyped's core principle: Every piece of data is validated.** Unlike raw Firestore operations, FirestoreTyped ensures data integrity by requiring validators for all operations.
+**FirestoreTyped's core principle: no collection without a validator.** Unlike raw Firestore operations, every write is validated by default, and reads are validated as well when `validateOnRead` is enabled (off by default for performance).
 
 ```typescript
 // ❌ Raw Firestore - No validation, potential runtime errors
@@ -200,7 +200,8 @@ await usersCollection.doc('user-001').set({
 
 // ✅ This data will be validated after read (if validateOnRead: true)
 const user = await usersCollection.doc('user-001').get()
-// user.data is guaranteed to match UserEntity or throw validation error
+// With validateOnRead: true, user.data is guaranteed to match UserEntity
+// (or a validation error is thrown); without it, data is returned as-is
 ```
 
 ### Using Custom Firestore Instances


### PR DESCRIPTION
## Summary

Closes #95 (Medium severity, from the 2026-07-10 external code review).

The README promised mandatory validation on **both read and write**, but the actual default is `validateOnRead: false` — so unvalidated data was returned typed as `T` while the documentation claimed a guarantee. Of the two options discussed in #95, the decision is **(a) fix the documentation** (non-breaking); flipping the default to `validateOnRead: true` was considered and deferred — it would be a behavior/perf breaking change that should be benchmarked and proposed separately if wanted.

## Changes (README.md / README.ja.md, 4 sites each)

- **Intro (line 8)**: "mandatory runtime validation ... during both read and write" → validator-first design: every collection requires a validator; writes validated by default, reads validated when `validateOnRead` is enabled
- **Key Features bullet**: same correction
- **"Core principle" statement**: "Every piece of data is validated" → "no collection without a validator", with the actual read/write default spelled out
- **Basic Usage guarantee comment**: the "`user.data` is guaranteed to match UserEntity" claim is now explicitly conditional on `validateOnRead: true`

What remains true and unchanged: validators are architecturally mandatory per collection, and writes are validated by default.

Documentation-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)