### PR TITLE
docs: CHANGELOG for v0.7.0, version bump

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,48 @@
 このフォーマットは[Keep a Changelog](https://keepachangelog.com/en/1.0.0/)に基づいており、
 このプロジェクトは[セマンティックバージョニング](https://semver.org/spec/v2.0.0.html)に準拠しています。
 
+## [0.7.0] - 2026-07-10
+
+このリリースの全項目は外部コードレビュー(issue #92〜#100)に基づきます。
+
+### 修正
+
+- **`failIfExists`が原子的になりました**(#92): `set(data, { failIfExists: true })`が
+  非原子的な読み取り→書き込みではなくFirestoreの`create()`を使うようになり、
+  同時の作成試行が両方成功することがなくなりました。gRPCの`ALREADY_EXISTS`エラーは
+  従来どおり`DocumentAlreadyExistsError`に変換されます
+- **特殊型フィールドへのクエリが一致するようになりました**(#93): `where()`のオペランドと
+  カーソル値(`startAt`/`startAfter`/`endAt`/`endBefore`)がネイティブFirestore型に変換されます
+  (`SerializedGeoPoint`→`GeoPoint`、`SerializedDocumentReference`→`DocumentReference`)。
+  従来はこれらのクエリが暗黙に0件を返していました
+- **`merge()`が並行更新を失わなくなりました**(#94): 読み取り→マージ→書き込みが
+  トランザクション内で実行され、読み書きの間にコミットされた更新は上書きされず
+  リトライされます
+- **`Buffer`/`Uint8Array`フィールドが保持されます**(#97): バイナリ値が両方向の変換を
+  そのまま通過します。従来は読み書き双方でインデックスキーのプレーンマップに破損していました
+
+### 変更
+
+- **破壊的変更(型レベル)**: `where()`のオペランド型が演算子を表現するようになりました(#96) —
+  `in`/`not-in`は`readonly T[K][]`、`array-contains`は配列要素型、`array-contains-any`は
+  要素の配列を取ります。誤った型のオペランド(主に`as any`経由)を渡していたコードでは
+  新たな型エラーが出る可能性があります。実行時挙動は不変です
+- **破壊的変更(型レベル)**: `SerializedDocumentReference<TCollection, TDocument>`の
+  `TDocument`がブランド化され(#98)、異なるドキュメント型への参照は相互代入できなくなりました。
+  既存のオブジェクトリテラルは有効なままです(ブランドメンバーはオプショナル)
+- **挙動**: `failIfExists`使用時、バリデーションが存在チェックより先に実行されます。
+  既存ドキュメントに不正データを書き込もうとした場合、`DocumentAlreadyExistsError`ではなく
+  `FirestoreTypedValidationError`がスローされます(#92)
+- CIが専用ジョブで`firebase emulators:exec`によるエミュレータテストを実行するようになりました(#99)
+
+### ドキュメント
+
+- READMEのバリデーションに関する記述を実際のデフォルトに合わせました(#95):
+  全コレクションにバリデータ必須、書き込みはデフォルト検証、読み取り検証は
+  `validateOnRead: true`でオプトイン
+- README APIリファレンスを実装と一致させました(#100): `getFirestoreTyped`のシグネチャ修正、
+  存在しないコレクショングループメソッドの削除
+
 ## [0.6.1] - 2026-07-10
 
 ### 変更

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-07-10
+
+All items in this release come from an external code review (issues #92–#100).
+
+### Fixed
+
+- **`failIfExists` is now atomic** (#92): `set(data, { failIfExists: true })` uses Firestore's
+  `create()` instead of a non-atomic read-then-write, so two concurrent creation attempts can
+  no longer both succeed. The gRPC `ALREADY_EXISTS` error is translated to
+  `DocumentAlreadyExistsError` as before
+- **Queries on special-type fields now match** (#93): `where()` operands and cursor values
+  (`startAt`/`startAfter`/`endAt`/`endBefore`) are converted to native Firestore types
+  (`SerializedGeoPoint` → `GeoPoint`, `SerializedDocumentReference` → `DocumentReference`).
+  Previously such queries silently returned 0 results
+- **`merge()` no longer loses concurrent updates** (#94): the read-modify-write now runs inside
+  a transaction, so updates committed between the read and the write abort and retry the merge
+  instead of being overwritten
+- **`Buffer`/`Uint8Array` fields are preserved** (#97): binary values pass through both
+  conversion directions unchanged; previously they were corrupted into index-keyed plain maps
+  on write and read
+
+### Changed
+
+- **BREAKING (type-level)**: `where()` operand types now model the operator (#96) —
+  `in`/`not-in` take `readonly T[K][]`, `array-contains` takes the array element type,
+  `array-contains-any` takes an array of elements. Code that passed mistyped operands
+  (typically via `as any`) may surface new type errors; runtime behavior is unchanged
+- **BREAKING (type-level)**: `SerializedDocumentReference<TCollection, TDocument>` now brands
+  `TDocument` (#98), so references to different document types are no longer mutually
+  assignable. Existing object literals remain valid (the brand member is optional)
+- **Behavior**: with `failIfExists`, validation now runs before the existence check; invalid
+  data targeting an existing document throws `FirestoreTypedValidationError` instead of
+  `DocumentAlreadyExistsError` (#92)
+- CI now runs emulator tests in a dedicated job via `firebase emulators:exec` (#99)
+
+### Documentation
+
+- README validation claims now match the actual defaults (#95): every collection requires a
+  validator, writes are validated by default, read validation is opt-in via `validateOnRead: true`
+- README API reference aligned with the implemented API (#100): fixed the `getFirestoreTyped`
+  signature and removed non-existent collection-group methods
+
 ## [0.6.1] - 2026-07-10
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@info-lounge/firestore-typed",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Type-safe, low-level wrapper for Firebase Firestore with enhanced validation and developer experience",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

Prepares the v0.7.0 release. All items come from the 2026-07-10 external code review (issues #92–#100), now fully resolved.

## Changes

- `package.json`: 0.6.1 → 0.7.0
- `CHANGELOG.md` / `CHANGELOG.ja.md`: `[0.7.0]` section

## Why 0.7.0 (not a patch)

- Two type-level breaking changes (#96 where() operand types, #98 SerializedDocumentReference branding) — consumer code may surface new type errors
- One behavior change (#92: validation ordering with failIfExists)
- The three high-severity fixes change observable behavior (queries that returned 0 results now match; concurrent merges now retry)

## Release plan

After merging: develop → main PR triggers the release (publish via OIDC — proven with 0.6.1 — plus tag and GitHub Release from this CHANGELOG section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)