### PR TITLE
fix: pass native Firestore values through query-operand conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@info-lounge/firestore-typed",
-  "version": "0.5.5",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@info-lounge/firestore-typed",
-      "version": "0.5.5",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/src/__tests__/__helpers__/firebase-mock.helper.ts
+++ b/src/__tests__/__helpers__/firebase-mock.helper.ts
@@ -240,6 +240,7 @@ export const createFirebaseAdminMock = () => ({
   Timestamp: MockTimestamp,
   GeoPoint: MockGeoPoint,
   DocumentReference: MockDocumentReferenceForTypeConversion,
+  DocumentSnapshot: MockDocumentSnapshot,
 })
 
 // This is a helper file, not a test file - no tests needed here

--- a/src/core/__tests__/emulator/firestore-typed.emulator.test.ts
+++ b/src/core/__tests__/emulator/firestore-typed.emulator.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import { GeoPoint } from 'firebase-admin/firestore'
 import { FirestoreTyped } from '../../firestore-typed'
 import { DocumentAlreadyExistsError } from '../../../errors/errors'
 import type {
@@ -198,6 +199,68 @@ describe('FirestoreTyped Core Class (Emulator)', () => {
         const byOwner = await collection.where('owner', '==', owner).get()
         expect(byOwner.size).toBe(1)
         expect(byOwner.docs[0].data?.name).toBe('Tokyo Office')
+      } finally {
+        await docRef.delete()
+      }
+    })
+  })
+
+  describe('Native operands for queries and cursors', () => {
+    it('should accept a native DocumentSnapshot as a cursor value', async () => {
+      const validator = createSimpleTestEntityValidator()
+      const uniqueCollectionName = `test-cursor-${Date.now()}-${Math.random()}`
+      const collection = firestoreTyped.collection(uniqueCollectionName, validator)
+
+      const docRefs = await Promise.all([
+        collection.add(createSimpleTestEntity({ id: '1', name: 'Alice' })),
+        collection.add(createSimpleTestEntity({ id: '2', name: 'Bob' })),
+        collection.add(createSimpleTestEntity({ id: '3', name: 'Carol' })),
+      ])
+
+      try {
+        // Native snapshots contain circular references; before the passthrough
+        // fix this overflowed the stack (RangeError) in cursor conversion
+        const nativeSnapshot = await collection.native.orderBy('name').get()
+
+        const page = await collection
+          .orderBy('name')
+          .startAfter(nativeSnapshot.docs[0])
+          .get({ validateOnRead: false })
+
+        expect(page.size).toBe(2)
+        expect(page.docs.map((d) => d.data?.name)).toEqual(['Bob', 'Carol'])
+      } finally {
+        await Promise.all(docRefs.map((ref) => ref.delete()))
+      }
+    })
+
+    it('should match documents when a native GeoPoint is used as a where() operand', async () => {
+      interface PlaceEntity extends Record<string, unknown> {
+        id: string
+        name: string
+        location: SerializedGeoPoint
+      }
+      const validator = (data: unknown) => data as PlaceEntity
+      const uniqueCollectionName = `test-native-geo-${Date.now()}-${Math.random()}`
+      const collection = firestoreTyped.collection<PlaceEntity>(uniqueCollectionName, validator)
+
+      const docRef = collection.doc('osaka')
+      await docRef.set({
+        id: 'osaka',
+        name: 'Osaka Office',
+        location: { type: 'GeoPoint', latitude: 34.6937, longitude: 135.5023 },
+      })
+
+      try {
+        // Native instances worked before 0.7.0's query-value conversion and
+        // must keep working: they pass through instead of being flattened
+        const nativeGeoPoint = new GeoPoint(34.6937, 135.5023)
+        const result = await collection
+          .where('location', '==', nativeGeoPoint as unknown as SerializedGeoPoint)
+          .get()
+
+        expect(result.size).toBe(1)
+        expect(result.docs[0].data?.name).toBe('Osaka Office')
       } finally {
         await docRef.delete()
       }

--- a/src/core/__tests__/unit/query.unit.test.ts
+++ b/src/core/__tests__/unit/query.unit.test.ts
@@ -98,6 +98,24 @@ describe('Query', () => {
         expect(mockFirebaseQuery.where).toHaveBeenCalledTimes(2)
       })
 
+      it('should accept array-contains on optional and nullable array fields', () => {
+        interface OptionalArrays extends Record<string, unknown> {
+          tags?: string[]
+          labels: string[] | null
+        }
+        const optQuery = new Query<OptionalArrays>(
+          mockFirebaseQuery,
+          mockFirestoreTyped,
+          vi.fn((data) => data as OptionalArrays),
+        )
+
+        // Both compile because WhereFilterValue extracts the array part of the union
+        optQuery.where('tags', 'array-contains', 'important')
+        optQuery.where('labels', 'array-contains', 'urgent')
+
+        expect(mockFirebaseQuery.where).toHaveBeenCalledTimes(2)
+      })
+
       it('should be chainable', () => {
         const result = query
           .where('name', '==', 'John')

--- a/src/types/firestore-typed.types.ts
+++ b/src/types/firestore-typed.types.ts
@@ -67,11 +67,11 @@ export type WhereFilterValue<
 > = Op extends 'in' | 'not-in'
   ? readonly T[K][]
   : Op extends 'array-contains'
-    ? T[K] extends readonly (infer E)[]
+    ? Extract<T[K], readonly unknown[]> extends readonly (infer E)[]
       ? E
       : never
     : Op extends 'array-contains-any'
-      ? T[K] extends readonly (infer E)[]
+      ? Extract<T[K], readonly unknown[]> extends readonly (infer E)[]
         ? readonly E[]
         : never
       : T[K]

--- a/src/utils/__tests__/unit/firestore-converter.unit.test.ts
+++ b/src/utils/__tests__/unit/firestore-converter.unit.test.ts
@@ -2,7 +2,13 @@
 import { vi, describe, it, expect, beforeEach, type Mocked } from 'vitest'
 import { serializeFirestoreTypes, deserializeFirestoreTypes } from '../../firestore-converter'
 import type { SerializedGeoPoint, SerializedDocumentReference } from '../../firestore-converter'
-import { Timestamp, GeoPoint, DocumentReference, Firestore } from 'firebase-admin/firestore'
+import {
+  Timestamp,
+  GeoPoint,
+  DocumentReference,
+  DocumentSnapshot,
+  Firestore,
+} from 'firebase-admin/firestore'
 
 describe('Firestore Converter', () => {
   let mockFirestore: Mocked<Firestore>
@@ -520,6 +526,33 @@ describe('Firestore Converter', () => {
 
       const result = deserializeFirestoreTypes({ author: validDocRef }, mockFirestore) as any
       expect(result.author).toBe(mockDocRef)
+    })
+
+    it('should pass native Firestore instances through unchanged', () => {
+      const nativeTimestamp = createMockTimestamp(new Date('2024-01-01'))
+      const nativeGeoPoint = createMockGeoPoint(35.6762, 139.6503)
+      const nativeDocRef = createMockDocumentReference('users/user123', 'user123', 'users')
+
+      const result = deserializeFirestoreTypes(
+        { at: nativeTimestamp, loc: nativeGeoPoint, ref: nativeDocRef },
+        mockFirestore,
+      ) as any
+
+      expect(result.at).toBe(nativeTimestamp)
+      expect(result.loc).toBe(nativeGeoPoint)
+      expect(result.ref).toBe(nativeDocRef)
+    })
+
+    it('should pass DocumentSnapshot values through without walking their circular internals', () => {
+      // Native snapshots hold circular references (e.g. back to the Firestore
+      // client); recursing into them overflows the stack
+      const snapshotLike: Record<string, unknown> = {}
+      snapshotLike._firestore = { _snapshot: snapshotLike }
+      Object.setPrototypeOf(snapshotLike, DocumentSnapshot.prototype)
+
+      const result = deserializeFirestoreTypes({ cursor: snapshotLike }, mockFirestore) as any
+
+      expect(result.cursor).toBe(snapshotLike)
     })
 
     it('should pass binary values through unchanged', () => {

--- a/src/utils/firestore-converter.ts
+++ b/src/utils/firestore-converter.ts
@@ -1,4 +1,10 @@
-import { Timestamp, GeoPoint, DocumentReference, Firestore } from 'firebase-admin/firestore'
+import {
+  Timestamp,
+  GeoPoint,
+  DocumentReference,
+  DocumentSnapshot,
+  Firestore,
+} from 'firebase-admin/firestore'
 import type { DocumentData } from 'firebase-admin/firestore'
 import type { SerializedDocumentData } from '../types/firestore-typed.types'
 
@@ -132,6 +138,18 @@ export function deserializeQueryValue(value: unknown, firestore: Firestore): unk
  */
 function deserializeFirestoreTypesInternal(data: unknown, firestore: Firestore): unknown {
   if (!data || typeof data !== 'object') {
+    return data
+  }
+
+  // Values that are already native Firestore types pass through unchanged.
+  // Walking them with Object.entries would corrupt them — and DocumentSnapshot
+  // (a valid cursor value) contains circular references that overflow the stack.
+  if (
+    data instanceof Timestamp ||
+    data instanceof GeoPoint ||
+    data instanceof DocumentReference ||
+    data instanceof DocumentSnapshot
+  ) {
     return data
   }
 


### PR DESCRIPTION
## Summary

Fixes findings 1, 2, and 4 from the follow-up review of the unreleased 0.7.0 changes. **Should merge before the release PR #112.**

## Finding 1 (High): native operands corrupted / stack overflow — regression from #105

`deserializeFirestoreTypesInternal` walked any unrecognized object via `Object.entries`, so:
- native `Timestamp` / `GeoPoint` / `DocumentReference` operands were flattened into plain objects — queries with native operands worked before #105 and broke after it (verified by probe)
- a native `DocumentSnapshot` as a cursor value — the canonical Firestore pagination pattern — recursed into circular internals and threw `RangeError` (verified by probe with a circular object)

**Fix**: instances of `Timestamp` / `GeoPoint` / `DocumentReference` / `DocumentSnapshot` now pass through unchanged (early check before the recursive walk).

## Finding 2 (Medium): array-contains unusable on optional/nullable array fields — regression from #108

`WhereFilterValue` required `T[K] extends readonly unknown[]`, so `tags?: string[]` and `string[] | null` collapsed the operand type to `never` (verified by type probe). **Fix**: `Extract<T[K], readonly unknown[]>` pulls the array member out of the union before inferring the element type.

## Finding 4 (Low): package-lock.json root version

Was still 0.5.5; synced to 0.7.0 via `npm install`.

## Tests

- Unit: native-instance passthrough; circular snapshot-like object no longer crashes; positive compile tests for optional/nullable `array-contains`
- Emulator: `startAfter(nativeSnapshot.docs[0])` paginates correctly (RangeError before the fix); native `GeoPoint` `where()` operand matches a stored document
- Mock helper now exports `DocumentSnapshot` (needed by the new instanceof check)

Finding 3 (release workflow gating) is addressed separately in the next PR.

## Verification

- ✅ `npm test` — 250 tests pass
- ✅ `npm run test:emulator` — 11 tests pass
- ✅ `npm run typecheck` / `lint` (exit codes checked explicitly this time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)