### PR TITLE
ci: gate npm publish on emulator tests; make release steps idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,12 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
+      - name: Setup Java (required by the Firestore emulator)
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       - name: Get package version
         id: package-version
         run: |
@@ -29,23 +35,38 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Check if version exists on npm
+      # Idempotent release state: each publish/tag/release step below is
+      # skipped if its artifact already exists, so a partially-failed run
+      # can be re-run and will complete only the missing pieces.
+      - name: Check release state
+        id: state
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=${{ steps.package-version.outputs.version }}
-          if npm view @info-lounge/firestore-typed@$VERSION version 2>/dev/null; then
-            echo "Version $VERSION already exists on npm"
-            exit 1
-          fi
-          echo "Version $VERSION is available for publishing"
-
-      - name: Check if tag exists
-        run: |
           TAG=${{ steps.package-version.outputs.tag }}
-          if git tag -l | grep -q "^$TAG$"; then
-            echo "Tag $TAG already exists"
-            exit 1
+
+          if npm view @info-lounge/firestore-typed@$VERSION version 2>/dev/null; then
+            echo "Version $VERSION already on npm — publish will be skipped"
+            echo "published=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version $VERSION is not on npm yet"
+            echo "published=false" >> $GITHUB_OUTPUT
           fi
-          echo "Tag $TAG is available"
+
+          if git tag -l | grep -q "^$TAG$"; then
+            echo "Tag $TAG already exists — tagging will be skipped"
+            echo "tagged=true" >> $GITHUB_OUTPUT
+          else
+            echo "tagged=false" >> $GITHUB_OUTPUT
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub Release $TAG already exists — release creation will be skipped"
+            echo "released=true" >> $GITHUB_OUTPUT
+          else
+            echo "released=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Install dependencies
         run: npm ci
@@ -62,6 +83,9 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Run emulator tests
+        run: npx --yes firebase-tools@15 emulators:exec --project demo-firestore-typed --only firestore 'npm run test:emulator'
+
       - name: Build package
         run: npm run build
 
@@ -69,9 +93,11 @@ jobs:
       # Requires the trusted publisher configured on npmjs.com for this repo/workflow
       # and the id-token: write permission declared above.
       - name: Publish to npm
+        if: steps.state.outputs.published == 'false'
         run: npm publish --access public
 
       - name: Create Git tag
+        if: steps.state.outputs.tagged == 'false'
         run: |
           TAG=${{ steps.package-version.outputs.tag }}
           git config user.name "github-actions[bot]"
@@ -80,26 +106,28 @@ jobs:
           git push origin $TAG
 
       - name: Extract changelog for this version
+        if: steps.state.outputs.released == 'false'
         id: changelog
         run: |
           VERSION=${{ steps.package-version.outputs.version }}
-          
+
           # Extract changelog section for this version
           awk -v version="[$VERSION]" '
-            /^## \[/ { 
+            /^## \[/ {
               if (found) exit
               if ($0 ~ version) found=1
             }
             found && !/^## \[/ { print }
             found && /^## \[/ && $0 !~ version { exit }
           ' CHANGELOG.md > release_notes.md
-          
+
           # Remove the first empty line if it exists
           sed -i '1{/^$/d;}' release_notes.md
-          
+
           echo "Release notes extracted for version $VERSION"
 
       - name: Create GitHub Release
+        if: steps.state.outputs.released == 'false'
         run: |
           gh release create ${{ steps.package-version.outputs.tag }} \
             --title "Release ${{ steps.package-version.outputs.tag }}" \


### PR DESCRIPTION
## Summary

Fixes finding 3 from the follow-up review of the 0.7.0 release candidate.

Two gaps in release.yml:
1. **Emulator tests did not gate publishing** — they run in the parallel CI workflow, which cannot block the release workflow on a main push. A change failing only under the real Firestore emulator could be published anyway.
2. **Partial releases were unrecoverable** — `npm publish` ran before tag/GitHub Release creation, and the version/tag guards hard-failed the whole run when the artifact existed. If anything after publish failed, re-running was impossible (the version-exists guard rejected it), leaving a published package with no tag or release notes.

## Changes

- **Emulator gate**: `firebase emulators:exec ... npm run test:emulator` runs before `npm publish`, using the same command as the CI job from #103 (plus `setup-java`, required by the Firestore emulator)
- **Idempotent release steps**: a single "Check release state" step probes npm, git tags, and GitHub Releases, and each subsequent step is individually skipped when its artifact already exists:
  - re-running a run that failed after publish now completes the missing tag/release instead of failing the version guard
  - a push to main without a version bump now completes as a no-op (with explicit skip notices) instead of a red run

## Notes

- Step ordering (publish → tag → release) is unchanged; recoverability now comes from idempotency rather than ordering
- No untrusted inputs are interpolated into run blocks (version comes from package.json)

## Verification

- Workflow logic change only; exercised on the next release run (0.7.0). The state-check shell was validated locally with both existing and missing versions/tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)