### PR TITLE
docs: fold follow-up review fixes into the 0.7.0 CHANGELOG

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -18,7 +18,8 @@
 - **特殊型フィールドへのクエリが一致するようになりました**(#93): `where()`のオペランドと
   カーソル値(`startAt`/`startAfter`/`endAt`/`endBefore`)がネイティブFirestore型に変換されます
   (`SerializedGeoPoint`→`GeoPoint`、`SerializedDocumentReference`→`DocumentReference`)。
-  従来はこれらのクエリが暗黙に0件を返していました
+  従来はこれらのクエリが暗黙に0件を返していました。すでにネイティブな値(`Timestamp`、
+  `GeoPoint`、`DocumentReference`、カーソルの`DocumentSnapshot`)はそのまま通過します
 - **`merge()`が並行更新を失わなくなりました**(#94): 読み取り→マージ→書き込みが
   トランザクション内で実行され、読み書きの間にコミットされた更新は上書きされず
   リトライされます
@@ -28,7 +29,8 @@
 ### 変更
 
 - **破壊的変更(型レベル)**: `where()`のオペランド型が演算子を表現するようになりました(#96) —
-  `in`/`not-in`は`readonly T[K][]`、`array-contains`は配列要素型、`array-contains-any`は
+  `in`/`not-in`は`readonly T[K][]`、`array-contains`は配列要素型
+  (`tags?: string[]`のようなoptional/nullable配列フィールドにも対応)、`array-contains-any`は
   要素の配列を取ります。誤った型のオペランド(主に`as any`経由)を渡していたコードでは
   新たな型エラーが出る可能性があります。実行時挙動は不変です
 - **破壊的変更(型レベル)**: `SerializedDocumentReference<TCollection, TDocument>`の
@@ -38,6 +40,8 @@
   既存ドキュメントに不正データを書き込もうとした場合、`DocumentAlreadyExistsError`ではなく
   `FirestoreTypedValidationError`がスローされます(#92)
 - CIが専用ジョブで`firebase emulators:exec`によるエミュレータテストを実行するようになりました(#99)
+- リリースワークフローが公開前にエミュレータテストを実行し、publish・タグ・GitHub Releaseの
+  各ステップがイデンポテントになりました(途中失敗したリリースrunを安全に再実行できます)
 
 ### ドキュメント
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ All items in this release come from an external code review (issues #92–#100).
 - **Queries on special-type fields now match** (#93): `where()` operands and cursor values
   (`startAt`/`startAfter`/`endAt`/`endBefore`) are converted to native Firestore types
   (`SerializedGeoPoint` → `GeoPoint`, `SerializedDocumentReference` → `DocumentReference`).
-  Previously such queries silently returned 0 results
+  Previously such queries silently returned 0 results. Values that are already native
+  (`Timestamp`, `GeoPoint`, `DocumentReference`, and `DocumentSnapshot` cursors) pass
+  through unchanged
 - **`merge()` no longer loses concurrent updates** (#94): the read-modify-write now runs inside
   a transaction, so updates committed between the read and the write abort and retry the merge
   instead of being overwritten
@@ -29,7 +31,8 @@ All items in this release come from an external code review (issues #92–#100).
 ### Changed
 
 - **BREAKING (type-level)**: `where()` operand types now model the operator (#96) —
-  `in`/`not-in` take `readonly T[K][]`, `array-contains` takes the array element type,
+  `in`/`not-in` take `readonly T[K][]`, `array-contains` takes the array element type
+  (including for optional/nullable array fields such as `tags?: string[]`),
   `array-contains-any` takes an array of elements. Code that passed mistyped operands
   (typically via `as any`) may surface new type errors; runtime behavior is unchanged
 - **BREAKING (type-level)**: `SerializedDocumentReference<TCollection, TDocument>` now brands
@@ -39,6 +42,8 @@ All items in this release come from an external code review (issues #92–#100).
   data targeting an existing document throws `FirestoreTypedValidationError` instead of
   `DocumentAlreadyExistsError` (#92)
 - CI now runs emulator tests in a dedicated job via `firebase emulators:exec` (#99)
+- The release workflow now runs emulator tests before publishing, and its publish/tag/release
+  steps are idempotent so a partially failed release run can be safely re-run
 
 ### Documentation
 


### PR DESCRIPTION
## Summary

The `[0.7.0]` CHANGELOG section was written in #111, before the follow-up review fixes (#113, #114) landed. The existing entries do not contradict the final implementation, but three details were missing. Applied to both CHANGELOG.md and CHANGELOG.ja.md:

- **#93 entry**: already-native values (`Timestamp`, `GeoPoint`, `DocumentReference`, and `DocumentSnapshot` cursors) pass through unchanged — relevant for users using native-operand patterns
- **#96 entry**: `array-contains` works on optional/nullable array fields (`tags?: string[]`)
- **New line**: the release workflow now gates publishing on emulator tests and its publish/tag/release steps are idempotent (#114)

Documentation-only. These notes ship in the GitHub Release for v0.7.0 (extracted from this section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)