### PR TITLE
types: accept native Firestore operands in where(); reject undefined

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -29,10 +29,12 @@
 ### 変更
 
 - **破壊的変更(型レベル)**: `where()`のオペランド型が演算子を表現するようになりました(#96) —
-  `in`/`not-in`は`readonly T[K][]`、`array-contains`は配列要素型
+  `in`/`not-in`はフィールド値の配列、`array-contains`は配列要素型
   (`tags?: string[]`のようなoptional/nullable配列フィールドにも対応)、`array-contains-any`は
-  要素の配列を取ります。誤った型のオペランド(主に`as any`経由)を渡していたコードでは
-  新たな型エラーが出る可能性があります。実行時挙動は不変です
+  要素の配列を取ります。ネイティブFirestore値(`Timestamp`、`GeoPoint`、`DocumentReference`)は
+  シリアライズ形式と並んで受け付けられ、`undefined`はオペランドとして拒否されます
+  (Firestoreが実行時に拒否するため)。誤った型のオペランド(主に`as any`経由)を渡していた
+  コードでは新たな型エラーが出る可能性があります。実行時挙動は不変です
 - **破壊的変更(型レベル)**: `SerializedDocumentReference<TCollection, TDocument>`の
   `TDocument`がブランド化され(#98)、異なるドキュメント型への参照は相互代入できなくなりました。
   既存のオブジェクトリテラルは有効なままです(ブランドメンバーはオプショナル)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,13 @@ All items in this release come from an external code review (issues #92–#100).
 ### Changed
 
 - **BREAKING (type-level)**: `where()` operand types now model the operator (#96) —
-  `in`/`not-in` take `readonly T[K][]`, `array-contains` takes the array element type
+  `in`/`not-in` take an array of field values, `array-contains` takes the array element type
   (including for optional/nullable array fields such as `tags?: string[]`),
-  `array-contains-any` takes an array of elements. Code that passed mistyped operands
-  (typically via `as any`) may surface new type errors; runtime behavior is unchanged
+  `array-contains-any` takes an array of elements. Native Firestore values (`Timestamp`,
+  `GeoPoint`, `DocumentReference`) are accepted alongside their serialized forms, and
+  `undefined` is rejected as an operand (Firestore rejects it at runtime). Code that passed
+  mistyped operands (typically via `as any`) may surface new type errors; runtime behavior
+  is unchanged
 - **BREAKING (type-level)**: `SerializedDocumentReference<TCollection, TDocument>` now brands
   `TDocument` (#98), so references to different document types are no longer mutually
   assignable. Existing object literals remain valid (the brand member is optional)

--- a/src/core/__tests__/emulator/firestore-typed.emulator.test.ts
+++ b/src/core/__tests__/emulator/firestore-typed.emulator.test.ts
@@ -253,11 +253,10 @@ describe('FirestoreTyped Core Class (Emulator)', () => {
 
       try {
         // Native instances worked before 0.7.0's query-value conversion and
-        // must keep working: they pass through instead of being flattened
+        // must keep working: they pass through instead of being flattened,
+        // and WhereFilterValue accepts them alongside the serialized form
         const nativeGeoPoint = new GeoPoint(34.6937, 135.5023)
-        const result = await collection
-          .where('location', '==', nativeGeoPoint as unknown as SerializedGeoPoint)
-          .get()
+        const result = await collection.where('location', '==', nativeGeoPoint).get()
 
         expect(result.size).toBe(1)
         expect(result.docs[0].data?.name).toBe('Osaka Office')

--- a/src/core/__tests__/unit/query.unit.test.ts
+++ b/src/core/__tests__/unit/query.unit.test.ts
@@ -1,6 +1,8 @@
 import { vi, describe, it, expect, beforeEach, type Mock, type MockedFunction } from 'vitest'
+import { GeoPoint, Timestamp } from 'firebase-admin/firestore'
 import { Query } from '../../query'
 import { serializeFirestoreTypes, deserializeQueryValue } from '../../../utils/firestore-converter'
+import type { SerializedGeoPoint } from '../../../utils/firestore-converter'
 import { validateData } from '../../../utils/validator'
 import type { FirestoreTypedOptionsProvider } from '../../../types/firestore-typed.types'
 import {
@@ -96,6 +98,28 @@ describe('Query', () => {
         query.where('age', '==', [18])
 
         expect(mockFirebaseQuery.where).toHaveBeenCalledTimes(2)
+      })
+
+      it('should reject undefined operands and accept native Firestore counterparts', () => {
+        interface MixedEntity extends Record<string, unknown> {
+          name?: string
+          location: SerializedGeoPoint
+          createdAt: Date
+        }
+        const mixedQuery = new Query<MixedEntity>(
+          mockFirebaseQuery,
+          mockFirestoreTyped,
+          vi.fn((data) => data as MixedEntity),
+        )
+
+        // @ts-expect-error undefined is rejected by Firestore at runtime, so the types forbid it
+        mixedQuery.where('name', '==', undefined)
+
+        // Native counterparts are accepted alongside serialized forms
+        mixedQuery.where('location', '==', new GeoPoint(35.6, 139.6))
+        mixedQuery.where('createdAt', '>=', Timestamp.fromDate(new Date('2024-01-01')))
+
+        expect(mockFirebaseQuery.where).toHaveBeenCalledTimes(3)
       })
 
       it('should accept array-contains on optional and nullable array fields', () => {

--- a/src/types/firestore-typed.types.ts
+++ b/src/types/firestore-typed.types.ts
@@ -54,27 +54,51 @@ export interface WriteOptions {
 export type SerializedDocumentData = object
 
 /**
+ * Native Firestore counterpart of a serialized value type: Date fields also
+ * accept Timestamp operands, SerializedGeoPoint fields accept GeoPoint, and
+ * SerializedDocumentReference fields accept DocumentReference (all pass
+ * through query-value conversion unchanged).
+ */
+type NativeQueryOperand<V> = V extends Date
+  ? import('firebase-admin/firestore').Timestamp
+  : V extends import('../utils/firestore-converter').SerializedGeoPoint
+    ? import('firebase-admin/firestore').GeoPoint
+    : V extends import('../utils/firestore-converter').SerializedDocumentReference
+      ? import('firebase-admin/firestore').DocumentReference
+      : never
+
+/**
+ * A single query operand for field values of type V:
+ * the value itself (undefined excluded — Firestore rejects undefined
+ * operands at runtime) or its native Firestore counterpart.
+ */
+type QueryOperand<V> = Exclude<V, undefined> | NativeQueryOperand<Exclude<V, undefined>>
+
+/**
  * Maps a Firestore where() operator to the operand type it expects for field K:
  * - `in` / `not-in` compare against an array of field values
  * - `array-contains` compares against a single element of an array field
  * - `array-contains-any` compares against an array of elements of an array field
  * - all other operators compare against the field value itself
+ *
+ * Native Firestore values (Timestamp, GeoPoint, DocumentReference) are accepted
+ * alongside their serialized forms; undefined is never a valid operand.
  */
 export type WhereFilterValue<
   T,
   K extends keyof T,
   Op extends import('firebase-admin/firestore').WhereFilterOp,
 > = Op extends 'in' | 'not-in'
-  ? readonly T[K][]
+  ? readonly QueryOperand<T[K]>[]
   : Op extends 'array-contains'
     ? Extract<T[K], readonly unknown[]> extends readonly (infer E)[]
-      ? E
+      ? QueryOperand<E>
       : never
     : Op extends 'array-contains-any'
       ? Extract<T[K], readonly unknown[]> extends readonly (infer E)[]
-        ? readonly E[]
+        ? readonly QueryOperand<E>[]
         : never
-      : T[K]
+      : QueryOperand<T[K]>
 
 /**
  * Metadata about a document


### PR DESCRIPTION
## Summary

Fixes the two low-severity findings from the latest review round — both are refinements to the 0.7.0 type work, folded in before release so the type surface only breaks once.

## Finding 1: native values supported at runtime but not in types

Since #113, native `Timestamp` / `GeoPoint` / `DocumentReference` operands pass through query conversion, but `WhereFilterValue` still only accepted serialized entity types — our own emulator test needed `as unknown as SerializedGeoPoint`. New `QueryOperand<V>` unions each field value with its native counterpart:

| Field type | Accepted operands |
|---|---|
| `Date` | `Date` \| `Timestamp` |
| `SerializedGeoPoint` | serialized \| `GeoPoint` |
| `SerializedDocumentReference` | serialized \| `DocumentReference` |

The emulator test's double cast is now gone (compile-time proof).

## Finding 2: `undefined` compiled as an operand for optional fields

`where('name', '==', undefined)` compiled for `name?: string` but Firestore rejects undefined at runtime. `undefined` is now excluded from every operand position (equality, `in`/`not-in` elements, array-contains elements). `null` remains valid — Firestore supports it.

## Verification

- ✅ `npm test` — 251 tests (new compile-time tests: `@ts-expect-error` on undefined operand; positive native `GeoPoint`/`Timestamp` operands)
- ✅ `npm run test:emulator` — 11 tests (native GeoPoint test now cast-free)
- ✅ `npm run typecheck` / `lint`
- CHANGELOG (en/ja) #96 entry updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)