### PR TITLE
docs: reflect 0.7.0 behavior in README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,9 @@ import { FirestoreTyped, CollectionReference, DocumentReference, Query, Collecti
 - `Date` → `Timestamp` (loses nanosecond precision)
 - `SerializedGeoPoint` → `GeoPoint`
 - `SerializedDocumentReference<TCollection, TDocument>` → `DocumentReference`
+- `Buffer`/`Uint8Array` pass through unchanged (Firestore bytes fields)
+- Already-native values (`Timestamp`, `GeoPoint`, `DocumentReference`, `DocumentSnapshot` cursors) pass through unchanged, including as query operands
+- `merge()` runs its read-modify-write inside a transaction; `failIfExists` uses atomic `create()`
 
 ### Testing Strategy
 The codebase uses a three-tiered testing approach:

--- a/README.ja.md
+++ b/README.ja.md
@@ -443,6 +443,7 @@ await collection.doc('id').set(data, { validateOnWrite: false })
 // 上書きせずにドキュメントを作成
 await collection.doc('id').set(data, { failIfExists: true })
 // ドキュメントが既に存在する場合はDocumentAlreadyExistsErrorをスロー
+// (Firestoreのcreate()によるサーバー側の原子的な強制 — 並行実行でも安全)
 ```
 
 ### ドキュメントの読み取り
@@ -466,6 +467,7 @@ const documents = querySnapshot.docs.map(doc => doc.data)
 - FirestoreTypedでは`set(data, { merge: true })`の代わりに専用の`merge()`メソッドを使用します
 - `merge`操作は**完全にマージされたデータ**に対してバリデーションを実行します
 - **ドキュメントが存在する必要があります** - ドキュメントが存在しない場合は`DocumentNotFoundError`をスロー
+- 読み取り→マージ→検証→書き込みの一連は**トランザクション内で実行**されます: 読み書きの間に他の更新がコミットされた場合、上書きせず最新データでリトライします
 - 生のFirestoreの`set(..., { merge: true })`パターンはFirestoreTypedでは利用できません
 
 ```typescript
@@ -608,8 +610,16 @@ const sortedQuery = usersCollection.orderBy('createdAt', 'desc')
 // ❌ 無効なフィールド名のコンパイルエラー
 // const invalidQuery = usersCollection.where('invalidField', '==', 'value')
 
-// ⚠️ 注意: 値の型やページネーションパラメータは完全に型チェックされません
-// const query = usersCollection.where('name', '==', 123) // 型エラーを捕捉できない可能性
+// ✅ オペランドの型は演算子ごとにチェックされます
+// usersCollection.where('name', '==', 123)        // ❌ numberはstringに代入不可
+// usersCollection.where('name', '==', undefined)  // ❌ undefinedはオペランドとして常に不正
+// usersCollection.where('status', 'in', ['active', 'inactive']) // ✅ 'in'は配列を取る
+// usersCollection.where('tags', 'array-contains', 'admin')      // ✅ 配列フィールドの要素型
+
+// ✅ ネイティブFirestore値もシリアライズ形式と並んで受け付けられます
+// usersCollection.where('createdAt', '>=', Timestamp.fromDate(date)) // DateフィールドはTimestampも可
+
+// ⚠️ 注意: ページネーションのカーソルパラメータは型チェックされません
 // const paginated = usersCollection.startAt('any', 'values') // パラメータはunknown[]
 ```
 
@@ -874,6 +884,9 @@ FirestoreTypedは書き込み操作時にJavaScript型をFirestore特殊型に�
 | `Date` | `Timestamp` | 日時データ変換（下記の精度に関する注意事項を参照） |
 | `SerializedGeoPoint` | `GeoPoint` | 地理的位置データ変換 |
 | `SerializedDocumentReference<TCollection, TDocument>` | `DocumentReference` | 型安全なドキュメント参照復元 |
+| `Buffer` / `Uint8Array` | Bytes | 両方向とも変換せずそのまま通過 |
+
+すでにネイティブなFirestore型(`Timestamp`、`GeoPoint`、`DocumentReference`)の値は、ドキュメントデータ内でもクエリのオペランドとしても、変換されずそのまま通過します。
 
 > **⚠️ Date/Timestamp精度に関する重要な注意事項**: JavaScript `Date`オブジェクトはミリ秒精度ですが、Firestore `Timestamp`オブジェクトはナノ秒精度をサポートしています。`Date`から`Timestamp`への変換時、ナノ秒部分は常に`000000`（ゼロ）になります。これは、元のFirestoreデータのナノ秒レベルの精度が変換プロセス中に失われることを意味します。
 

--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ await collection.doc('id').set(data, { validateOnWrite: false })
 // Ensure document creation without overwriting
 await collection.doc('id').set(data, { failIfExists: true })
 // Throws DocumentAlreadyExistsError if document already exists
+// (atomic — enforced server-side via Firestore's create(), safe under concurrency)
 ```
 
 ### Read Documents
@@ -467,6 +468,7 @@ const documents = querySnapshot.docs.map(doc => doc.data)
 - FirestoreTyped uses a dedicated `merge()` method instead of `set(data, { merge: true })`
 - The `merge` operation validates the **complete merged data**, not just the partial data being merged
 - **The document must exist** - throws `DocumentNotFoundError` if the document doesn't exist
+- The read-merge-validate-write sequence **runs inside a transaction**: a concurrent update between the read and the write causes the merge to retry against fresh data instead of overwriting it
 - Native Firestore's `set(..., { merge: true })` is not available in FirestoreTyped
 
 ```typescript
@@ -610,8 +612,16 @@ const sortedQuery = usersCollection.orderBy('createdAt', 'desc')
 // ❌ Compile errors for invalid field names
 // const invalidQuery = usersCollection.where('invalidField', '==', 'value')
 
-// ⚠️ Note: Value types and pagination parameters are not fully type-checked
-// const query = usersCollection.where('name', '==', 123) // May not catch type errors
+// ✅ Operand types are checked per operator
+// usersCollection.where('name', '==', 123)        // ❌ number is not assignable to string
+// usersCollection.where('name', '==', undefined)  // ❌ undefined is never a valid operand
+// usersCollection.where('status', 'in', ['active', 'inactive']) // ✅ 'in' takes an array
+// usersCollection.where('tags', 'array-contains', 'admin')      // ✅ element type of the array field
+
+// ✅ Native Firestore values are accepted alongside serialized forms
+// usersCollection.where('createdAt', '>=', Timestamp.fromDate(date)) // Date fields also take Timestamp
+
+// ⚠️ Note: pagination cursor parameters are not type-checked
 // const paginated = usersCollection.startAt('any', 'values') // Parameters are unknown[]
 ```
 
@@ -877,6 +887,9 @@ FirestoreTyped automatically handles the conversion of JavaScript types to Fires
 | `Date` | `Timestamp` | DateTime data conversion (see precision note below) |
 | `SerializedGeoPoint` | `GeoPoint` | Geographic location data conversion |
 | `SerializedDocumentReference<TCollection, TDocument>` | `DocumentReference` | Type-safe document reference restoration |
+| `Buffer` / `Uint8Array` | Bytes | Passed through unchanged in both directions |
+
+Values that are already native Firestore types (`Timestamp`, `GeoPoint`, `DocumentReference`) pass through unchanged, both in document data and as query operands.
 
 > **⚠️ Important Note on Date/Timestamp Precision**: JavaScript `Date` objects have millisecond precision, while Firestore `Timestamp` objects support nanosecond precision. When converting from `Date` to `Timestamp`, the nanosecond portion will always be `000000` (zero). This means any nanosecond-level precision from the original Firestore data will be lost during the conversion process.
 


### PR DESCRIPTION
## Summary

Documentation audit against the 0.7.0 changes found several sections describing pre-0.7.0 behavior. Applied to README.md, README.ja.md, and CLAUDE.md.

## Changes

- **Type conversion tables**: new `Buffer`/`Uint8Array` → Bytes passthrough row (#97), plus a note that already-native Firestore values pass through unchanged in document data and query operands (#113)
- **Query builder "Type Safety" section**: the note "Value types and pagination parameters are not fully type-checked" is stale since #96/#116 — operand types are now operator-aware, `undefined` is rejected, and native counterparts (`Timestamp` for `Date` fields, etc.) are accepted. Rewritten with concrete examples; the remaining genuine gap (cursor parameters are `unknown[]`) is kept
- **merge() notes**: document the transactional read-modify-write and retry-on-contention behavior (#94)
- **failIfExists example comment**: note atomicity via server-side `create()` (#92)
- **CLAUDE.md**: same conversion/concurrency facts added to the type-conversion section for future sessions

Documentation-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)